### PR TITLE
feat: 实现历届获奖存档页 (REQ-004)

### DIFF
--- a/src/app/archive/[seasonId]/page.tsx
+++ b/src/app/archive/[seasonId]/page.tsx
@@ -1,0 +1,90 @@
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import type { Metadata } from 'next'
+import { getSeasonById } from '@/lib/data'
+import ProjectCard from '@/components/ProjectCard'
+
+type Props = {
+  params: Promise<{ seasonId: string }>
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { seasonId } = await params
+  const season = await getSeasonById(seasonId)
+  if (!season) return { title: '届次未找到 · 反内卷 AI 榜' }
+  return {
+    title: `${season.name}获奖项目 · 反内卷 AI 榜`,
+    description: `回顾「反内卷 AI 榜」${season.name}的所有获奖 AI 项目`,
+  }
+}
+
+export default async function SeasonArchivePage({ params }: Props) {
+  const { seasonId } = await params
+  const season = await getSeasonById(seasonId)
+
+  if (!season) notFound()
+
+  const endTime = season.endAt
+    ? new Date(season.endAt).toLocaleDateString('zh-CN', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      })
+    : null
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      {/* 顶部导航 */}
+      <div className="border-b border-gray-200 bg-white">
+        <div className="mx-auto max-w-5xl px-4 py-3 flex items-center gap-3 text-sm">
+          <Link href="/" className="text-indigo-600 hover:text-indigo-800 transition">
+            首页
+          </Link>
+          <span className="text-gray-300">/</span>
+          <Link href="/archive" className="text-indigo-600 hover:text-indigo-800 transition">
+            历届存档
+          </Link>
+          <span className="text-gray-300">/</span>
+          <span className="text-gray-500">{season.name}</span>
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-5xl px-4 py-10">
+        {/* 页面标题 */}
+        <header className="mb-8">
+          <h1 className="text-3xl font-extrabold text-gray-900 sm:text-4xl">
+            🏆 {season.name}
+          </h1>
+          {endTime && (
+            <p className="mt-2 text-sm text-gray-500">颁奖时间：{endTime}</p>
+          )}
+        </header>
+
+        {/* 获奖项目列表 */}
+        {season.projects.length === 0 ? (
+          <div className="rounded-2xl border border-dashed border-gray-300 bg-white py-20 text-center text-gray-400">
+            <p className="text-4xl mb-3">🏅</p>
+            <p className="text-lg font-medium">本届暂无获奖项目</p>
+            <p className="mt-1 text-sm">颁奖结果公布后将在此展示</p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+            {season.projects.map((project) => (
+              <ProjectCard key={project.id} project={project} highlight />
+            ))}
+          </div>
+        )}
+
+        {/* 返回存档列表 */}
+        <div className="mt-10 text-center">
+          <Link
+            href="/archive"
+            className="inline-block text-sm text-indigo-600 hover:text-indigo-800 transition"
+          >
+            ← 查看所有届次
+          </Link>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/app/archive/page.tsx
+++ b/src/app/archive/page.tsx
@@ -1,10 +1,108 @@
-export default function ArchivePage() {
+import Link from 'next/link'
+import type { Metadata } from 'next'
+import { getAllSeasons } from '@/lib/data'
+
+export const metadata: Metadata = {
+  title: '历届存档 · 反内卷 AI 榜',
+  description: '回顾每届「反内卷 AI 榜」的获奖项目',
+}
+
+const STATUS_MAP: Record<string, { label: string; color: string }> = {
+  ACTIVE: { label: '候选中', color: 'bg-green-100 text-green-700' },
+  UPCOMING: { label: '即将开始', color: 'bg-blue-100 text-blue-700' },
+  ARCHIVED: { label: '已结束', color: 'bg-gray-100 text-gray-500' },
+}
+
+export default async function ArchivePage() {
+  const seasons = await getAllSeasons()
+
   return (
-    <main className="min-h-screen bg-gray-50 flex items-center justify-center">
-      <div className="text-center text-gray-400">
-        <p className="text-4xl mb-3">🗄️</p>
-        <p className="text-lg font-medium">历届存档开发中</p>
+    <main className="min-h-screen bg-gray-50">
+      {/* 顶部导航 */}
+      <div className="border-b border-gray-200 bg-white">
+        <div className="mx-auto max-w-3xl px-4 py-3">
+          <Link href="/" className="text-sm text-indigo-600 hover:text-indigo-800 transition">
+            ← 返回榜单首页
+          </Link>
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-3xl px-4 py-10">
+        <h1 className="text-3xl font-extrabold text-gray-900 mb-2">🗄️ 历届存档</h1>
+        <p className="text-gray-500 mb-8">每届的获奖 AI 永久存档于此</p>
+
+        {seasons.length === 0 ? (
+          // 暂无届次
+          <div className="rounded-2xl border border-dashed border-gray-300 bg-white py-20 text-center text-gray-400">
+            <p className="text-4xl mb-3">📭</p>
+            <p className="text-lg font-medium">暂无历届记录</p>
+          </div>
+        ) : seasons.length === 1 ? (
+          // 只有一届：直接跳转到该届详情
+          <SeasonCard season={seasons[0]} single />
+        ) : (
+          // 多届：列表展示
+          <div className="space-y-4">
+            {seasons.map((season) => (
+              <SeasonCard key={season.id} season={season} />
+            ))}
+          </div>
+        )}
       </div>
     </main>
+  )
+}
+
+type SeasonCardProps = {
+  season: {
+    id: string
+    name: string
+    status: string
+    startAt: Date | null
+    endAt: Date | null
+    createdAt: Date
+    _count: { projects: number }
+  }
+  single?: boolean
+}
+
+function SeasonCard({ season, single }: SeasonCardProps) {
+  const statusInfo = STATUS_MAP[season.status] ?? STATUS_MAP.ARCHIVED
+  const endTime = season.endAt
+    ? new Date(season.endAt).toLocaleDateString('zh-CN', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      })
+    : null
+
+  return (
+    <Link
+      href={`/archive/${season.id}`}
+      className="group flex items-center justify-between rounded-2xl border border-gray-200 bg-white p-6 hover:border-indigo-300 hover:shadow-sm transition"
+    >
+      <div>
+        <div className="flex items-center gap-2 mb-1">
+          <h2 className="text-lg font-bold text-gray-900 group-hover:text-indigo-600">
+            {season.name}
+          </h2>
+          <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${statusInfo.color}`}>
+            {statusInfo.label}
+          </span>
+          {single && (
+            <span className="rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-medium text-indigo-700">
+              当前唯一届次
+            </span>
+          )}
+        </div>
+        <p className="text-sm text-gray-500">
+          {season._count.projects > 0
+            ? `${season._count.projects} 个获奖项目`
+            : '暂无获奖项目'}
+          {endTime && ` · 颁奖于 ${endTime}`}
+        </p>
+      </div>
+      <span className="text-2xl text-gray-300 group-hover:text-indigo-400 transition">→</span>
+    </Link>
   )
 }

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -77,6 +77,44 @@ export type ProjectDetail = ProjectWithCounts & {
   submissions: SubmissionPublic[]
 }
 
+/** 获取所有届次，按创建时间倒序（用于存档列表页） */
+export async function getAllSeasons(): Promise<
+  Array<{
+    id: string
+    name: string
+    status: string
+    startAt: Date | null
+    endAt: Date | null
+    createdAt: Date
+    _count: { projects: number }
+  }>
+> {
+  const seasons = await prisma.season.findMany({
+    orderBy: { createdAt: 'desc' },
+    include: {
+      _count: { select: { projects: true } },
+    },
+  })
+  return seasons
+}
+
+/** 获取某届次的详情及所有获奖项目 */
+export async function getSeasonById(seasonId: string): Promise<SeasonWithProjects | null> {
+  const season = await prisma.season.findUnique({
+    where: { id: seasonId },
+    include: {
+      projects: {
+        where: { isActive: true, award: { not: null } },
+        include: {
+          _count: { select: { likes: true, comments: true } },
+        },
+        orderBy: { createdAt: 'asc' },
+      },
+    },
+  })
+  return season as SeasonWithProjects | null
+}
+
 /** 通过 slug 获取单个项目详情（含届次信息 & 公开自荐记录） */
 export async function getProjectBySlug(slug: string): Promise<ProjectDetail | null> {
   const project = await prisma.project.findUnique({


### PR DESCRIPTION
## 变更概述

实现 Issue #4「历届获奖存档页」所有功能需求。

## 实现内容

### /archive 列表页
- 按届次倒序展示所有届次
- 每届卡片：届次名称、状态标签（候选中/即将开始/已结束）、获奖项目数量、颁奖时间
- 只有一届时：显示「当前唯一届次」标签，仍可点击进入详情
- 暂无届次时：显示占位提示

### /archive/[seasonId] 详情页
- 面包屑导航：首页 / 历届存档 / 届次名
- 展示该届所有获奖项目（award 不为 null）卡片网格
- 卡片可跳转至 /ai/{slug}（复用 ProjectCard 组件，highlight 样式）
- 该届 0 获奖项目时：显示「本届暂无获奖项目」占位

### 数据层新增
- `getAllSeasons()` — 获取所有届次倒序，含项目计数
- `getSeasonById()` — 获取单届详情，只含获奖项目（award != null）

## 验收清单
- [x] /archive 可正常访问，按届次倒序展示
- [x] 点击某届可进入该届详情
- [x] 卡片可跳转至 AI 详情页（/ai/{slug}）
- [x] 边界情况正确处理（0届/1届/0项目）
- [x] 移动端响应式
- [x] 独立 title/description（SEO）
- [x] 本地 build 通过 ✅

Closes #4