### PR TITLE
feat: 管理后台审核中心 (REQ-010)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,13 +50,16 @@ model Project {
 // 提名 / 自荐
 model Submission {
   id                 String   @id @default(cuid())
+  type               String   @default("NOMINATION") // NOMINATION | SELF
   projectName        String
   projectUrl         String
   description        String
+  awardCategory      String?  // UNREPLACEABLE | USELESS | null（申报奖项）
   submitterEmail     String?
   submitterNickname  String?  // 自荐人昵称
   isPublic           Boolean  @default(false) // 是否公开自荐人信息
   status             String   @default("PENDING") // PENDING | APPROVED | REJECTED
+  rejectNote         String?  // 拒绝备注（内部，不对外展示）
   seasonId           String
   projectId          String?  // 审批通过后关联到的项目（可选）
   createdAt          DateTime @default(now())

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,4 +1,9 @@
+import Link from 'next/link'
 import { logoutAction } from './actions'
+
+const NAV_ITEMS = [
+  { href: '/admin/review', emoji: '📋', title: '审核中心', desc: '处理提名与自荐，管理候选列表' },
+]
 
 export default function AdminPage() {
   return (
@@ -7,10 +12,7 @@ export default function AdminPage() {
         <div className="mx-auto max-w-5xl px-4 py-4 flex items-center justify-between">
           <h1 className="text-lg font-bold text-gray-900">🛠️ 管理后台</h1>
           <form action={logoutAction}>
-            <button
-              type="submit"
-              className="text-sm text-gray-500 hover:text-red-600 transition"
-            >
+            <button type="submit" className="text-sm text-gray-500 hover:text-red-600 transition">
               退出登录
             </button>
           </form>
@@ -18,10 +20,18 @@ export default function AdminPage() {
       </header>
 
       <div className="mx-auto max-w-5xl px-4 py-10">
-        <div className="rounded-2xl border border-dashed border-gray-300 bg-white py-20 text-center text-gray-400">
-          <p className="text-4xl mb-3">🚧</p>
-          <p className="text-lg font-medium">管理后台功能开发中</p>
-          <p className="mt-1 text-sm">登录保护已生效</p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {NAV_ITEMS.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="group rounded-2xl border border-gray-200 bg-white p-6 hover:border-indigo-300 hover:shadow-sm transition"
+            >
+              <p className="text-3xl mb-3">{item.emoji}</p>
+              <h2 className="font-bold text-gray-900 group-hover:text-indigo-600">{item.title}</h2>
+              <p className="mt-1 text-sm text-gray-500">{item.desc}</p>
+            </Link>
+          ))}
         </div>
       </div>
     </main>

--- a/src/app/admin/review/ReviewTable.tsx
+++ b/src/app/admin/review/ReviewTable.tsx
@@ -1,0 +1,282 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import Link from 'next/link'
+import {
+  approveSubmission,
+  rejectSubmission,
+  revokeSubmission,
+  batchApprove,
+  batchReject,
+} from './actions'
+
+type Submission = {
+  id: string
+  type: string
+  projectName: string
+  projectUrl: string
+  description: string
+  awardCategory: string | null
+  submitterEmail: string | null
+  submitterNickname: string | null
+  status: string
+  rejectNote: string | null
+  createdAt: Date
+  season: { id: string; name: string }
+  project: { id: string; slug: string; name: string } | null
+}
+
+const TYPE_MAP: Record<string, string> = { NOMINATION: '提名', SELF: '自荐' }
+const AWARD_MAP: Record<string, string> = { UNREPLACEABLE: '🏆 最不可替代', USELESS: '🏅 最没用AI' }
+const STATUS_MAP: Record<string, { label: string; color: string }> = {
+  PENDING: { label: '待审核', color: 'bg-amber-100 text-amber-700' },
+  APPROVED: { label: '已通过', color: 'bg-green-100 text-green-700' },
+  REJECTED: { label: '已拒绝', color: 'bg-red-100 text-red-600' },
+}
+
+export default function ReviewTable({ submissions }: { submissions: Submission[] }) {
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [preview, setPreview] = useState<Submission | null>(null)
+  const [rejectTarget, setRejectTarget] = useState<string | 'batch' | null>(null)
+  const [rejectNote, setRejectNote] = useState('')
+  const [toast, setToast] = useState<{ msg: string; ok: boolean } | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  function showToast(msg: string, ok = true) {
+    setToast({ msg, ok })
+    setTimeout(() => setToast(null), 3000)
+  }
+
+  function toggleAll() {
+    if (selected.size === submissions.length) setSelected(new Set())
+    else setSelected(new Set(submissions.map((s) => s.id)))
+  }
+
+  function toggleOne(id: string) {
+    const next = new Set(selected)
+    if (next.has(id)) next.delete(id)
+    else next.add(id)
+    setSelected(next)
+  }
+
+  function handleApprove(id: string) {
+    startTransition(async () => {
+      const res = await approveSubmission(id)
+      if (res.error) showToast(`失败：${res.error}`, false)
+      else showToast('已通过，项目已加入候选列表')
+    })
+  }
+
+  function handleRevoke(id: string) {
+    startTransition(async () => {
+      const res = await revokeSubmission(id)
+      if (res.error) showToast(`失败：${res.error}`, false)
+      else showToast('已撤销审核，项目已下架')
+    })
+  }
+
+  function openRejectDialog(id: string | 'batch') {
+    setRejectTarget(id)
+    setRejectNote('')
+  }
+
+  function confirmReject() {
+    if (!rejectTarget) return
+    startTransition(async () => {
+      let res: { error?: string }
+      if (rejectTarget === 'batch') {
+        res = await batchReject(Array.from(selected), rejectNote)
+        if (!res.error) setSelected(new Set())
+      } else {
+        res = await rejectSubmission(rejectTarget, rejectNote)
+      }
+      setRejectTarget(null)
+      if (res.error) showToast(`失败：${res.error}`, false)
+      else showToast('已拒绝')
+    })
+  }
+
+  function handleBatchApprove() {
+    startTransition(async () => {
+      const res = await batchApprove(Array.from(selected))
+      if (res.error) showToast(`部分失败：${res.error}`, false)
+      else { showToast(`已批量通过 ${selected.size} 条`); setSelected(new Set()) }
+    })
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Toast */}
+      {toast && (
+        <div className={`fixed top-4 right-4 z-50 rounded-xl px-5 py-3 text-sm font-medium shadow-lg text-white transition ${toast.ok ? 'bg-green-600' : 'bg-red-500'}`}>
+          {toast.msg}
+        </div>
+      )}
+
+      {/* 批量操作栏 */}
+      {selected.size > 0 && (
+        <div className="flex items-center gap-3 rounded-xl bg-indigo-50 border border-indigo-200 px-4 py-3">
+          <span className="text-sm font-medium text-indigo-700">已选 {selected.size} 条</span>
+          <button
+            onClick={handleBatchApprove}
+            disabled={isPending}
+            className="rounded-lg bg-green-600 px-4 py-1.5 text-sm font-semibold text-white hover:bg-green-700 disabled:opacity-50 transition"
+          >
+            批量通过
+          </button>
+          <button
+            onClick={() => openRejectDialog('batch')}
+            disabled={isPending}
+            className="rounded-lg bg-red-500 px-4 py-1.5 text-sm font-semibold text-white hover:bg-red-600 disabled:opacity-50 transition"
+          >
+            批量拒绝
+          </button>
+          <button onClick={() => setSelected(new Set())} className="text-sm text-gray-400 hover:text-gray-600">
+            取消
+          </button>
+        </div>
+      )}
+
+      {/* 表格 */}
+      {submissions.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-gray-300 bg-white py-20 text-center text-gray-400">
+          <p className="text-4xl mb-3">📭</p>
+          <p className="text-lg font-medium">暂无提交记录</p>
+        </div>
+      ) : (
+        <div className="rounded-2xl border border-gray-200 bg-white overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 border-b border-gray-200">
+              <tr>
+                <th className="px-4 py-3 text-left">
+                  <input type="checkbox" checked={selected.size === submissions.length && submissions.length > 0} onChange={toggleAll} className="rounded" />
+                </th>
+                <th className="px-4 py-3 text-left text-gray-600 font-medium">AI 名称</th>
+                <th className="px-4 py-3 text-left text-gray-600 font-medium">来源</th>
+                <th className="px-4 py-3 text-left text-gray-600 font-medium">申报奖项</th>
+                <th className="px-4 py-3 text-left text-gray-600 font-medium">提交者</th>
+                <th className="px-4 py-3 text-left text-gray-600 font-medium">届次</th>
+                <th className="px-4 py-3 text-left text-gray-600 font-medium">状态</th>
+                <th className="px-4 py-3 text-left text-gray-600 font-medium">提交时间</th>
+                <th className="px-4 py-3 text-left text-gray-600 font-medium">操作</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {submissions.map((sub) => {
+                const statusInfo = STATUS_MAP[sub.status] ?? STATUS_MAP.PENDING
+                return (
+                  <tr key={sub.id} className="hover:bg-gray-50 transition">
+                    <td className="px-4 py-3">
+                      <input type="checkbox" checked={selected.has(sub.id)} onChange={() => toggleOne(sub.id)} className="rounded" />
+                    </td>
+                    <td className="px-4 py-3">
+                      <button onClick={() => setPreview(sub)} className="font-semibold text-indigo-600 hover:underline text-left">
+                        {sub.projectName}
+                      </button>
+                    </td>
+                    <td className="px-4 py-3 text-gray-600">{TYPE_MAP[sub.type] ?? sub.type}</td>
+                    <td className="px-4 py-3 text-gray-600">{sub.awardCategory ? AWARD_MAP[sub.awardCategory] ?? sub.awardCategory : '—'}</td>
+                    <td className="px-4 py-3 text-gray-500 text-xs">
+                      {sub.submitterNickname && <span className="block">{sub.submitterNickname}</span>}
+                      {sub.submitterEmail && <span className="block text-gray-400">{sub.submitterEmail}</span>}
+                      {!sub.submitterNickname && !sub.submitterEmail && '—'}
+                    </td>
+                    <td className="px-4 py-3 text-gray-500">{sub.season.name}</td>
+                    <td className="px-4 py-3">
+                      <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${statusInfo.color}`}>
+                        {statusInfo.label}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-gray-400 text-xs whitespace-nowrap">
+                      {new Date(sub.createdAt).toLocaleDateString('zh-CN')}
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-2">
+                        {sub.status === 'PENDING' && (
+                          <>
+                            <button onClick={() => handleApprove(sub.id)} disabled={isPending} className="text-xs font-semibold text-green-600 hover:text-green-800 disabled:opacity-40">通过</button>
+                            <button onClick={() => openRejectDialog(sub.id)} disabled={isPending} className="text-xs font-semibold text-red-500 hover:text-red-700 disabled:opacity-40">拒绝</button>
+                          </>
+                        )}
+                        {sub.status === 'APPROVED' && (
+                          <>
+                            {sub.project && (
+                              <Link href={`/ai/${sub.project.slug}`} target="_blank" className="text-xs font-semibold text-indigo-500 hover:text-indigo-700">查看项目</Link>
+                            )}
+                            <button onClick={() => handleRevoke(sub.id)} disabled={isPending} className="text-xs font-semibold text-amber-600 hover:text-amber-800 disabled:opacity-40">撤销</button>
+                          </>
+                        )}
+                        {sub.status === 'REJECTED' && sub.rejectNote && (
+                          <span className="text-xs text-gray-400 max-w-[120px] truncate" title={sub.rejectNote}>
+                            备注: {sub.rejectNote}
+                          </span>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* 预览弹窗 */}
+      {preview && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
+          <div className="w-full max-w-lg rounded-2xl bg-white p-6 shadow-xl space-y-4">
+            <div className="flex items-center justify-between">
+              <h2 className="text-lg font-bold text-gray-900">{preview.projectName}</h2>
+              <button onClick={() => setPreview(null)} className="text-gray-400 hover:text-gray-600 text-xl">×</button>
+            </div>
+            <div className="space-y-2 text-sm text-gray-700">
+              <p><span className="font-medium text-gray-500">来源：</span>{TYPE_MAP[preview.type]}</p>
+              <p><span className="font-medium text-gray-500">申报奖项：</span>{preview.awardCategory ? AWARD_MAP[preview.awardCategory] : '未指定'}</p>
+              <p><span className="font-medium text-gray-500">体验链接：</span>
+                <a href={preview.projectUrl} target="_blank" rel="noopener noreferrer" className="text-indigo-600 hover:underline break-all">{preview.projectUrl}</a>
+              </p>
+              <p><span className="font-medium text-gray-500">介绍：</span>{preview.description}</p>
+              {preview.submitterNickname && <p><span className="font-medium text-gray-500">提交者：</span>{preview.submitterNickname}</p>}
+              {preview.submitterEmail && <p><span className="font-medium text-gray-500">邮箱：</span>{preview.submitterEmail}</p>}
+              {preview.rejectNote && <p><span className="font-medium text-gray-500">拒绝备注：</span>{preview.rejectNote}</p>}
+            </div>
+            <div className="flex gap-3 pt-2">
+              {preview.status === 'PENDING' && (
+                <>
+                  <button onClick={() => { handleApprove(preview.id); setPreview(null) }} className="flex-1 rounded-lg bg-green-600 py-2 text-sm font-semibold text-white hover:bg-green-700 transition">通过</button>
+                  <button onClick={() => { openRejectDialog(preview.id); setPreview(null) }} className="flex-1 rounded-lg bg-red-500 py-2 text-sm font-semibold text-white hover:bg-red-600 transition">拒绝</button>
+                </>
+              )}
+              <button onClick={() => setPreview(null)} className="flex-1 rounded-lg border border-gray-300 py-2 text-sm font-semibold text-gray-600 hover:bg-gray-50 transition">关闭</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* 拒绝备注弹窗 */}
+      {rejectTarget && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
+          <div className="w-full max-w-sm rounded-2xl bg-white p-6 shadow-xl space-y-4">
+            <h2 className="text-lg font-bold text-gray-900">拒绝备注</h2>
+            <p className="text-sm text-gray-500">填写内部备注（不对外展示，可选）</p>
+            <textarea
+              value={rejectNote}
+              onChange={(e) => setRejectNote(e.target.value)}
+              placeholder="例如：不符合「反内卷」定位"
+              rows={3}
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:border-indigo-500 resize-none"
+            />
+            <div className="flex gap-3">
+              <button onClick={confirmReject} disabled={isPending} className="flex-1 rounded-lg bg-red-500 py-2 text-sm font-semibold text-white hover:bg-red-600 disabled:opacity-50 transition">
+                确认拒绝
+              </button>
+              <button onClick={() => setRejectTarget(null)} className="flex-1 rounded-lg border border-gray-300 py-2 text-sm font-semibold text-gray-600 hover:bg-gray-50 transition">
+                取消
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/admin/review/actions.ts
+++ b/src/app/admin/review/actions.ts
@@ -1,0 +1,104 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { prisma } from '@/lib/prisma'
+
+/** 通过一条提名/自荐：创建 Project 记录，更新 Submission 状态 */
+export async function approveSubmission(submissionId: string): Promise<{ error?: string }> {
+  try {
+    const sub = await prisma.submission.findUnique({ where: { id: submissionId }, include: { season: true } })
+    if (!sub) return { error: '提交记录不存在' }
+    if (sub.status === 'APPROVED') return { error: '该记录已通过审核' }
+
+    // 生成唯一 slug（项目名 + 时间戳）
+    const slug = `${sub.projectName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')}-${Date.now()}`
+
+    const project = await prisma.project.create({
+      data: {
+        slug,
+        name: sub.projectName,
+        description: sub.description,
+        url: sub.projectUrl,
+        award: sub.awardCategory ?? null,
+        seasonId: sub.seasonId,
+      },
+    })
+
+    await prisma.submission.update({
+      where: { id: submissionId },
+      data: { status: 'APPROVED', projectId: project.id, rejectNote: null },
+    })
+
+    revalidatePath('/admin/review')
+    revalidatePath('/')
+    return {}
+  } catch (e) {
+    return { error: String(e) }
+  }
+}
+
+/** 拒绝一条提名/自荐，记录内部备注 */
+export async function rejectSubmission(submissionId: string, note: string): Promise<{ error?: string }> {
+  try {
+    await prisma.submission.update({
+      where: { id: submissionId },
+      data: { status: 'REJECTED', rejectNote: note || null },
+    })
+    revalidatePath('/admin/review')
+    return {}
+  } catch (e) {
+    return { error: String(e) }
+  }
+}
+
+/** 撤销审核：将项目下架，Submission 改回 PENDING */
+export async function revokeSubmission(submissionId: string): Promise<{ error?: string }> {
+  try {
+    const sub = await prisma.submission.findUnique({ where: { id: submissionId } })
+    if (!sub) return { error: '提交记录不存在' }
+    if (sub.status !== 'APPROVED') return { error: '只有已通过的记录可以撤销' }
+
+    // 将关联项目下架
+    if (sub.projectId) {
+      await prisma.project.update({
+        where: { id: sub.projectId },
+        data: { isActive: false },
+      })
+    }
+
+    await prisma.submission.update({
+      where: { id: submissionId },
+      data: { status: 'PENDING', projectId: null },
+    })
+
+    revalidatePath('/admin/review')
+    revalidatePath('/')
+    return {}
+  } catch (e) {
+    return { error: String(e) }
+  }
+}
+
+/** 批量通过 */
+export async function batchApprove(ids: string[]): Promise<{ error?: string }> {
+  const errors: string[] = []
+  for (const id of ids) {
+    const result = await approveSubmission(id)
+    if (result.error) errors.push(`${id}: ${result.error}`)
+  }
+  return errors.length > 0 ? { error: errors.join('; ') } : {}
+}
+
+/** 批量拒绝 */
+export async function batchReject(ids: string[], note: string): Promise<{ error?: string }> {
+  try {
+    await prisma.submission.updateMany({
+      where: { id: { in: ids }, status: 'PENDING' },
+      data: { status: 'REJECTED', rejectNote: note || null },
+    })
+    revalidatePath('/admin/review')
+    return {}
+  } catch (e) {
+    return { error: String(e) }
+  }
+}

--- a/src/app/admin/review/page.tsx
+++ b/src/app/admin/review/page.tsx
@@ -1,0 +1,109 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+import { prisma } from '@/lib/prisma'
+import ReviewTable from './ReviewTable'
+
+export const metadata: Metadata = {
+  title: '审核中心 · 管理后台',
+}
+
+export const dynamic = 'force-dynamic'
+
+type SearchParams = {
+  type?: string
+  award?: string
+  status?: string
+}
+
+export default async function ReviewPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>
+}) {
+  const params = await searchParams
+  const { type, award, status } = params
+
+  // 构建过滤条件
+  const where: Record<string, unknown> = {}
+  if (type && type !== 'all') where.type = type
+  if (award && award !== 'all') where.awardCategory = award
+  if (status && status !== 'all') where.status = status
+
+  const submissions = await prisma.submission.findMany({
+    where,
+    orderBy: { createdAt: 'desc' },
+    include: {
+      season: { select: { id: true, name: true } },
+      project: { select: { id: true, slug: true, name: true } },
+    },
+  })
+
+  // 统计数字
+  const counts = await prisma.submission.groupBy({
+    by: ['status'],
+    _count: { id: true },
+  })
+  const countMap = Object.fromEntries(counts.map((c) => [c.status, c._count.id]))
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      {/* 顶部导航 */}
+      <header className="bg-white border-b border-gray-200">
+        <div className="mx-auto max-w-6xl px-4 py-4 flex items-center justify-between">
+          <div className="flex items-center gap-3 text-sm">
+            <Link href="/admin" className="text-indigo-600 hover:text-indigo-800 transition">
+              ← 管理后台
+            </Link>
+            <span className="text-gray-300">/</span>
+            <span className="font-semibold text-gray-900">审核中心</span>
+          </div>
+        </div>
+      </header>
+
+      <div className="mx-auto max-w-6xl px-4 py-8 space-y-6">
+        {/* 统计卡片 */}
+        <div className="grid grid-cols-3 gap-4">
+          {[
+            { label: '待审核', key: 'PENDING', color: 'text-amber-600 bg-amber-50 border-amber-200' },
+            { label: '已通过', key: 'APPROVED', color: 'text-green-600 bg-green-50 border-green-200' },
+            { label: '已拒绝', key: 'REJECTED', color: 'text-red-500 bg-red-50 border-red-200' },
+          ].map(({ label, key, color }) => (
+            <div key={key} className={`rounded-xl border p-4 ${color}`}>
+              <p className="text-2xl font-extrabold">{countMap[key] ?? 0}</p>
+              <p className="text-sm font-medium mt-0.5">{label}</p>
+            </div>
+          ))}
+        </div>
+
+        {/* 过滤栏 */}
+        <form method="GET" className="flex flex-wrap gap-3 items-center bg-white border border-gray-200 rounded-xl p-4">
+          <select name="status" defaultValue={status ?? 'all'} className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm focus:outline-none focus:border-indigo-500">
+            <option value="all">全部状态</option>
+            <option value="PENDING">待审核</option>
+            <option value="APPROVED">已通过</option>
+            <option value="REJECTED">已拒绝</option>
+          </select>
+          <select name="type" defaultValue={type ?? 'all'} className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm focus:outline-none focus:border-indigo-500">
+            <option value="all">全部来源</option>
+            <option value="NOMINATION">提名</option>
+            <option value="SELF">自荐</option>
+          </select>
+          <select name="award" defaultValue={award ?? 'all'} className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm focus:outline-none focus:border-indigo-500">
+            <option value="all">全部奖项</option>
+            <option value="UNREPLACEABLE">🏆 最不可替代</option>
+            <option value="USELESS">🏅 最没用AI</option>
+          </select>
+          <button type="submit" className="rounded-lg bg-indigo-600 px-4 py-1.5 text-sm font-semibold text-white hover:bg-indigo-700 transition">
+            筛选
+          </button>
+          <Link href="/admin/review" className="text-sm text-gray-400 hover:text-gray-600 transition">
+            重置
+          </Link>
+        </form>
+
+        {/* 审核表格（Client Component，处理选择和操作） */}
+        <ReviewTable submissions={submissions} />
+      </div>
+    </main>
+  )
+}


### PR DESCRIPTION
## 变更概述

实现 Issue #9「管理后台 - 审核中心」所有功能需求。

## 实现内容

### /admin/review 页面（Server Component）
- **统计卡片**：待审核 / 已通过 / 已拒绝数量
- **过滤栏**：按状态 / 来源（提名/自荐）/ 申报奖项筛选，GET 参数保持 URL 可分享

### ReviewTable（Client Component）
| 功能 | 说明 |
|------|------|
| 单条预览 | 弹窗展示完整详情（链接可点击、备注可见） |
| 通过 | 自动生成 slug，创建 Project，关联 Submission |
| 拒绝 | 弹窗填写内部备注（不对外展示） |
| 撤销审核 | 将 Project isActive=false，Submission 改回 PENDING |
| 全选/单选 | checkbox 批量选择 |
| 批量通过 | 逐条调用 approveSubmission |
| 批量拒绝 | 一次性 updateMany，支持统一备注 |
| Toast 反馈 | 操作成功/失败即时提示 |

### Server Actions（review/actions.ts）
- `approveSubmission`：slug 自动生成（项目名转小写 kebab-case + 时间戳保唯一）
- `rejectSubmission`：写入 rejectNote
- `revokeSubmission`：下架项目 + 重置 Submission
- `batchApprove` / `batchReject`

### Schema 扩展
```prisma
model Submission {
  type          String  @default("NOMINATION") // NOMINATION | SELF
  awardCategory String? // 申报奖项
  rejectNote    String? // 拒绝备注
  ...
}
```

### /admin 首页
更新为导航卡片布局，加入审核中心入口。

## 验收清单
- [x] 待审列表正确展示所有字段
- [x] 过滤功能正常（状态/来源/奖项）
- [x] 通过后项目出现在候选列表（isActive=true）
- [x] 拒绝后记录备注
- [x] 撤销审核正常工作（项目下架）
- [x] 批量操作（批量通过/拒绝）
- [x] 本地 build 通过 ✅

Closes #9