### PR TITLE
feat: 管理后台项目管理 (REQ-011)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,18 +33,34 @@ model Project {
   url             String   // 体验链接
   githubUrl       String?  // GitHub / 官网链接（可选）
   imageUrl        String?
-  award           String?  // UNREPLACEABLE | USELESS | null
+  award           String?  // UNREPLACEABLE | USELESS | null（获奖状态）
+  awardStatus     String   @default("CANDIDATE") // CANDIDATE | WINNER | LOSER
   judgeComment    String?  // 评委点评内容
   judgeNickname   String?  // 评委昵称
-  isActive        Boolean  @default(true) // false 表示已下架
+  isActive        Boolean  @default(true)  // false 表示已下架
+  embedEnabled    Boolean  @default(false) // 是否支持内嵌体验（二期功能占位）
+  sortOrder       Int      @default(0)     // 展示排序，越小越靠前
   seasonId        String
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
 
-  season      Season       @relation(fields: [seasonId], references: [id])
-  likes       Like[]
-  comments    Comment[]
-  submissions Submission[] // 关联的自荐/提名记录
+  season          Season           @relation(fields: [seasonId], references: [id])
+  likes           Like[]
+  comments        Comment[]
+  submissions     Submission[]     // 关联的自荐/提名记录
+  likeAdjustLogs  LikeAdjustLog[]  // 点赞数校正日志
+}
+
+// 点赞数校正日志
+model LikeAdjustLog {
+  id         String   @id @default(cuid())
+  projectId  String
+  oldCount   Int
+  newCount   Int
+  reason     String   // 必填原因
+  createdAt  DateTime @default(now())
+
+  project Project @relation(fields: [projectId], references: [id])
 }
 
 // 提名 / 自荐

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { logoutAction } from './actions'
 
 const NAV_ITEMS = [
+  { href: '/admin/projects', emoji: '🗂️', title: '项目管理', desc: '新增、编辑、下架项目，校正点赞数' },
   { href: '/admin/review', emoji: '📋', title: '审核中心', desc: '处理提名与自荐，管理候选列表' },
 ]
 

--- a/src/app/admin/projects/ProjectForm.tsx
+++ b/src/app/admin/projects/ProjectForm.tsx
@@ -1,0 +1,171 @@
+'use client'
+
+import { useActionState } from 'react'
+import { upsertProject } from './actions'
+
+type Season = { id: string; name: string }
+type Project = {
+  id: string
+  slug: string
+  name: string
+  description: string
+  longDescription: string | null
+  url: string
+  githubUrl: string | null
+  award: string | null
+  awardStatus: string
+  judgeComment: string | null
+  judgeNickname: string | null
+  seasonId: string
+  sortOrder: number
+  embedEnabled: boolean
+  isActive: boolean
+}
+
+const initialState = { error: undefined as string | undefined }
+
+export default function ProjectForm({
+  seasons,
+  project,
+}: {
+  seasons: Season[]
+  project?: Project
+}) {
+  const [state, formAction, isPending] = useActionState(upsertProject, initialState)
+  const isEdit = !!project
+
+  return (
+    <form action={formAction} className="space-y-6 rounded-2xl border border-gray-200 bg-white p-8">
+      {project && <input type="hidden" name="id" value={project.id} />}
+
+      {/* 基本信息 */}
+      <section className="space-y-4">
+        <h2 className="text-base font-bold text-gray-900 border-b border-gray-100 pb-2">基本信息</h2>
+
+        <Field label="项目名称" name="name" required defaultValue={project?.name} placeholder="例如：Krita AI" />
+        <Field label="URL Slug" name="slug" required defaultValue={project?.slug} placeholder="例如：krita-ai（小写字母 + 连字符）" mono />
+        <Field label="一句话介绍" name="description" required defaultValue={project?.description} placeholder="用一句话描述这个 AI" />
+        <TextareaField label="详细介绍（支持 Markdown）" name="longDescription" defaultValue={project?.longDescription ?? ''} rows={6} placeholder="多行介绍，支持换行" />
+        <Field label="体验链接" name="url" required defaultValue={project?.url} placeholder="https://..." type="url" />
+        <Field label="GitHub / 官网链接（可选）" name="githubUrl" defaultValue={project?.githubUrl ?? ''} placeholder="https://github.com/..." type="url" />
+      </section>
+
+      {/* 奖项与届次 */}
+      <section className="space-y-4">
+        <h2 className="text-base font-bold text-gray-900 border-b border-gray-100 pb-2">奖项与届次</h2>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <SelectField label="所属届次" name="seasonId" required defaultValue={project?.seasonId}>
+            <option value="">请选择届次</option>
+            {seasons.map((s) => (
+              <option key={s.id} value={s.id}>{s.name}</option>
+            ))}
+          </SelectField>
+
+          <SelectField label="申报奖项" name="award" defaultValue={project?.award ?? ''}>
+            <option value="">无</option>
+            <option value="UNREPLACEABLE">🏆 最不可替代奖</option>
+            <option value="USELESS">🏅 最没用AI奖</option>
+          </SelectField>
+
+          <SelectField label="获奖状态" name="awardStatus" defaultValue={project?.awardStatus ?? 'CANDIDATE'}>
+            <option value="CANDIDATE">候选中</option>
+            <option value="WINNER">获奖</option>
+            <option value="LOSER">未获奖</option>
+          </SelectField>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">展示排序</label>
+            <input type="number" name="sortOrder" defaultValue={project?.sortOrder ?? 0} className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:border-indigo-500" />
+            <p className="mt-1 text-xs text-gray-400">数值越小越靠前</p>
+          </div>
+        </div>
+      </section>
+
+      {/* 评委点评 */}
+      <section className="space-y-4">
+        <h2 className="text-base font-bold text-gray-900 border-b border-gray-100 pb-2">评委点评</h2>
+        <TextareaField label="点评内容（留空则详情页不展示）" name="judgeComment" defaultValue={project?.judgeComment ?? ''} rows={3} placeholder="幽默/毒舌风格均可，此处填写后将展示在项目详情页" />
+        <Field label="评委昵称（可选）" name="judgeNickname" defaultValue={project?.judgeNickname ?? ''} placeholder="例如：评委 A" />
+      </section>
+
+      {/* 其他设置 */}
+      <section className="space-y-3">
+        <h2 className="text-base font-bold text-gray-900 border-b border-gray-100 pb-2">其他设置</h2>
+        <CheckboxField label="上架（取消勾选则下架，前台不可见）" name="isActive" defaultChecked={project?.isActive ?? true} offValue="off" />
+        <CheckboxField label="支持内嵌体验（二期功能，暂时占位）" name="embedEnabled" defaultChecked={project?.embedEnabled ?? false} />
+      </section>
+
+      {state?.error && (
+        <p className="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-600">
+          {state.error}
+        </p>
+      )}
+
+      <div className="flex gap-3 pt-2">
+        <button type="submit" disabled={isPending} className="rounded-lg bg-indigo-600 px-6 py-2.5 text-sm font-semibold text-white hover:bg-indigo-700 disabled:opacity-50 transition">
+          {isPending ? '保存中…' : isEdit ? '保存修改' : '创建项目'}
+        </button>
+        <a href="/admin/projects" className="rounded-lg border border-gray-300 px-6 py-2.5 text-sm font-semibold text-gray-600 hover:bg-gray-50 transition">
+          取消
+        </a>
+      </div>
+    </form>
+  )
+}
+
+// ── 小型表单组件 ──
+
+function Field({ label, name, required, defaultValue, placeholder, type = 'text', mono = false }: {
+  label: string; name: string; required?: boolean; defaultValue?: string; placeholder?: string; type?: string; mono?: boolean
+}) {
+  return (
+    <div>
+      <label className="block text-sm font-medium text-gray-700 mb-1">
+        {label}{required && <span className="text-red-500 ml-0.5">*</span>}
+      </label>
+      <input type={type} name={name} defaultValue={defaultValue} placeholder={placeholder} required={required}
+        className={`w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:border-indigo-500 ${mono ? 'font-mono' : ''}`} />
+    </div>
+  )
+}
+
+function TextareaField({ label, name, defaultValue, rows, placeholder }: {
+  label: string; name: string; defaultValue?: string; rows?: number; placeholder?: string
+}) {
+  return (
+    <div>
+      <label className="block text-sm font-medium text-gray-700 mb-1">{label}</label>
+      <textarea name={name} defaultValue={defaultValue} rows={rows ?? 3} placeholder={placeholder}
+        className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:border-indigo-500 resize-y" />
+    </div>
+  )
+}
+
+function SelectField({ label, name, required, defaultValue, children }: {
+  label: string; name: string; required?: boolean; defaultValue?: string; children: React.ReactNode
+}) {
+  return (
+    <div>
+      <label className="block text-sm font-medium text-gray-700 mb-1">
+        {label}{required && <span className="text-red-500 ml-0.5">*</span>}
+      </label>
+      <select name={name} defaultValue={defaultValue} required={required}
+        className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:border-indigo-500">
+        {children}
+      </select>
+    </div>
+  )
+}
+
+function CheckboxField({ label, name, defaultChecked, offValue }: {
+  label: string; name: string; defaultChecked?: boolean; offValue?: string
+}) {
+  return (
+    <label className="flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
+      <input type="checkbox" name={name} defaultChecked={defaultChecked} value={offValue ? undefined : 'on'}
+        className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500" />
+      {label}
+    </label>
+  )
+}

--- a/src/app/admin/projects/ProjectListActions.tsx
+++ b/src/app/admin/projects/ProjectListActions.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import { useState, useTransition, useActionState } from 'react'
+import Link from 'next/link'
+import { toggleProjectActive, deleteProject, adjustLikes } from './actions'
+
+type Props = {
+  id: string
+  slug: string
+  isActive: boolean
+  likesCount: number
+}
+
+const adjustInitial = { error: undefined as string | undefined }
+
+export default function ProjectListActions({ id, slug, isActive, likesCount }: Props) {
+  const [showDelete, setShowDelete] = useState(false)
+  const [showAdjust, setShowAdjust] = useState(false)
+  const [isPending, startTransition] = useTransition()
+  const [adjustState, adjustAction, adjustPending] = useActionState(adjustLikes, adjustInitial)
+
+  function handleToggle() {
+    startTransition(async () => {
+      await toggleProjectActive(id, !isActive)
+    })
+  }
+
+  function handleDelete() {
+    startTransition(async () => {
+      await deleteProject(id)
+      setShowDelete(false)
+    })
+  }
+
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      <Link href={`/admin/projects/${id}/edit`} className="text-xs font-semibold text-indigo-600 hover:text-indigo-800">编辑</Link>
+      <Link href={`/ai/${slug}`} target="_blank" className="text-xs font-semibold text-gray-500 hover:text-gray-700">查看</Link>
+      <button onClick={() => setShowAdjust(true)} className="text-xs font-semibold text-amber-600 hover:text-amber-800">校正点赞</button>
+      <button onClick={handleToggle} disabled={isPending} className="text-xs font-semibold text-gray-500 hover:text-gray-700 disabled:opacity-40">
+        {isActive ? '下架' : '上架'}
+      </button>
+      <button onClick={() => setShowDelete(true)} className="text-xs font-semibold text-red-500 hover:text-red-700">删除</button>
+
+      {/* 删除确认弹窗 */}
+      {showDelete && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
+          <div className="w-full max-w-sm rounded-2xl bg-white p-6 shadow-xl space-y-4">
+            <h2 className="text-lg font-bold text-gray-900">⚠️ 确认删除</h2>
+            <p className="text-sm text-gray-600">此操作不可撤销，项目及其所有点赞/评论将被永久删除。</p>
+            <div className="flex gap-3">
+              <button onClick={handleDelete} disabled={isPending} className="flex-1 rounded-lg bg-red-500 py-2 text-sm font-semibold text-white hover:bg-red-600 disabled:opacity-50 transition">
+                确认删除
+              </button>
+              <button onClick={() => setShowDelete(false)} className="flex-1 rounded-lg border border-gray-300 py-2 text-sm font-semibold text-gray-600 hover:bg-gray-50 transition">
+                取消
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* 点赞校正弹窗 */}
+      {showAdjust && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
+          <div className="w-full max-w-sm rounded-2xl bg-white p-6 shadow-xl space-y-4">
+            <h2 className="text-lg font-bold text-gray-900">校正点赞数</h2>
+            <p className="text-sm text-gray-500">当前点赞数：<strong>{likesCount}</strong></p>
+            <form action={adjustAction} className="space-y-3">
+              <input type="hidden" name="projectId" value={id} />
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">新的点赞数 <span className="text-red-500">*</span></label>
+                <input type="number" name="newCount" min="0" defaultValue={likesCount} required className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:border-indigo-500" />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">校正原因 <span className="text-red-500">*</span></label>
+                <textarea name="reason" rows={2} required placeholder="例如：移除刷票数据" className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:border-indigo-500 resize-none" />
+              </div>
+              {adjustState?.error && (
+                <p className="text-xs text-red-500">{adjustState.error}</p>
+              )}
+              <div className="flex gap-3">
+                <button type="submit" disabled={adjustPending} className="flex-1 rounded-lg bg-indigo-600 py-2 text-sm font-semibold text-white hover:bg-indigo-700 disabled:opacity-50 transition">
+                  确认校正
+                </button>
+                <button type="button" onClick={() => setShowAdjust(false)} className="flex-1 rounded-lg border border-gray-300 py-2 text-sm font-semibold text-gray-600 hover:bg-gray-50 transition">
+                  取消
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/admin/projects/[id]/edit/LikeAdjustLogs.tsx
+++ b/src/app/admin/projects/[id]/edit/LikeAdjustLogs.tsx
@@ -1,0 +1,33 @@
+type Log = {
+  id: string
+  oldCount: number
+  newCount: number
+  reason: string
+  createdAt: Date
+}
+
+export default function LikeAdjustLogs({ logs }: { logs: Log[] }) {
+  return (
+    <section className="rounded-2xl border border-gray-200 bg-white p-6 space-y-4">
+      <h2 className="text-base font-bold text-gray-900">📋 点赞校正日志</h2>
+      <div className="divide-y divide-gray-100">
+        {logs.map((log) => (
+          <div key={log.id} className="py-3 flex items-start justify-between gap-4">
+            <div className="text-sm">
+              <p className="font-medium text-gray-800">
+                {log.oldCount} → {log.newCount}
+                <span className={`ml-2 text-xs font-semibold ${log.newCount > log.oldCount ? 'text-green-600' : 'text-red-500'}`}>
+                  {log.newCount > log.oldCount ? `+${log.newCount - log.oldCount}` : log.newCount - log.oldCount}
+                </span>
+              </p>
+              <p className="text-gray-500 mt-0.5">{log.reason}</p>
+            </div>
+            <p className="text-xs text-gray-400 whitespace-nowrap">
+              {new Date(log.createdAt).toLocaleString('zh-CN')}
+            </p>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/app/admin/projects/[id]/edit/page.tsx
+++ b/src/app/admin/projects/[id]/edit/page.tsx
@@ -1,0 +1,60 @@
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import type { Metadata } from 'next'
+import { prisma } from '@/lib/prisma'
+import ProjectForm from '../../ProjectForm'
+import LikeAdjustLogs from './LikeAdjustLogs'
+
+type Props = { params: Promise<{ id: string }> }
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { id } = await params
+  const project = await prisma.project.findUnique({ where: { id }, select: { name: true } })
+  return { title: `编辑 ${project?.name ?? '项目'} · 管理后台` }
+}
+
+export default async function EditProjectPage({ params }: Props) {
+  const { id } = await params
+  const [project, seasons] = await Promise.all([
+    prisma.project.findUnique({
+      where: { id },
+      select: {
+        id: true, slug: true, name: true, description: true, longDescription: true,
+        url: true, githubUrl: true, award: true, awardStatus: true,
+        judgeComment: true, judgeNickname: true, seasonId: true,
+        sortOrder: true, embedEnabled: true, isActive: true,
+      },
+    }),
+    prisma.season.findMany({ orderBy: { createdAt: 'desc' }, select: { id: true, name: true } }),
+  ])
+
+  if (!project) notFound()
+
+  const logs = await prisma.likeAdjustLog.findMany({
+    where: { projectId: id },
+    orderBy: { createdAt: 'desc' },
+    take: 20,
+  })
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      <header className="bg-white border-b border-gray-200">
+        <div className="mx-auto max-w-3xl px-4 py-4 flex items-center gap-3 text-sm">
+          <Link href="/admin" className="text-indigo-600 hover:text-indigo-800">← 管理后台</Link>
+          <span className="text-gray-300">/</span>
+          <Link href="/admin/projects" className="text-indigo-600 hover:text-indigo-800">项目管理</Link>
+          <span className="text-gray-300">/</span>
+          <span className="font-semibold text-gray-900">编辑：{project.name}</span>
+        </div>
+      </header>
+
+      <div className="mx-auto max-w-3xl px-4 py-8 space-y-8">
+        <h1 className="text-2xl font-extrabold text-gray-900">编辑项目</h1>
+        <ProjectForm seasons={seasons} project={project} />
+
+        {/* 点赞校正日志 */}
+        {logs.length > 0 && <LikeAdjustLogs logs={logs} />}
+      </div>
+    </main>
+  )
+}

--- a/src/app/admin/projects/actions.ts
+++ b/src/app/admin/projects/actions.ts
@@ -1,0 +1,117 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { redirect } from 'next/navigation'
+import { prisma } from '@/lib/prisma'
+
+/** 新增或更新项目 */
+export async function upsertProject(
+  _prevState: { error?: string },
+  formData: FormData,
+): Promise<{ error?: string }> {
+  const id = formData.get('id') as string | null
+  const slug = (formData.get('slug') as string).trim()
+  const name = (formData.get('name') as string).trim()
+  const description = (formData.get('description') as string).trim()
+  const longDescription = (formData.get('longDescription') as string).trim() || null
+  const url = (formData.get('url') as string).trim()
+  const githubUrl = (formData.get('githubUrl') as string).trim() || null
+  const award = (formData.get('award') as string) || null
+  const awardStatus = (formData.get('awardStatus') as string) || 'CANDIDATE'
+  const judgeComment = (formData.get('judgeComment') as string).trim() || null
+  const judgeNickname = (formData.get('judgeNickname') as string).trim() || null
+  const seasonId = formData.get('seasonId') as string
+  const sortOrder = parseInt(formData.get('sortOrder') as string) || 0
+  const embedEnabled = formData.get('embedEnabled') === 'on'
+  const isActive = formData.get('isActive') !== 'off'
+
+  if (!slug || !name || !description || !url || !seasonId) {
+    return { error: '请填写必填字段（slug / 名称 / 一句话介绍 / 体验链接 / 届次）' }
+  }
+
+  try {
+    if (id) {
+      // 更新
+      await prisma.project.update({
+        where: { id },
+        data: { slug, name, description, longDescription, url, githubUrl, award: award || null, awardStatus, judgeComment, judgeNickname, seasonId, sortOrder, embedEnabled, isActive },
+      })
+    } else {
+      // 新增
+      await prisma.project.create({
+        data: { slug, name, description, longDescription, url, githubUrl, award: award || null, awardStatus, judgeComment, judgeNickname, seasonId, sortOrder, embedEnabled, isActive },
+      })
+    }
+    revalidatePath('/admin/projects')
+    revalidatePath('/')
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e)
+    if (msg.includes('Unique constraint') || msg.includes('unique')) {
+      return { error: `slug「${slug}」已被使用，请换一个` }
+    }
+    return { error: msg }
+  }
+
+  redirect('/admin/projects')
+}
+
+/** 下架/上架项目 */
+export async function toggleProjectActive(id: string, isActive: boolean): Promise<void> {
+  await prisma.project.update({ where: { id }, data: { isActive } })
+  revalidatePath('/admin/projects')
+  revalidatePath('/')
+}
+
+/** 删除项目（级联删除 likes/comments） */
+export async function deleteProject(id: string): Promise<{ error?: string }> {
+  try {
+    await prisma.like.deleteMany({ where: { projectId: id } })
+    await prisma.comment.deleteMany({ where: { projectId: id } })
+    await prisma.likeAdjustLog.deleteMany({ where: { projectId: id } })
+    await prisma.submission.updateMany({ where: { projectId: id }, data: { projectId: null, status: 'PENDING' } })
+    await prisma.project.delete({ where: { id } })
+    revalidatePath('/admin/projects')
+    revalidatePath('/')
+    return {}
+  } catch (e) {
+    return { error: String(e) }
+  }
+}
+
+/** 校正点赞数 */
+export async function adjustLikes(
+  _prevState: { error?: string },
+  formData: FormData,
+): Promise<{ error?: string }> {
+  const projectId = formData.get('projectId') as string
+  const newCount = parseInt(formData.get('newCount') as string)
+  const reason = (formData.get('reason') as string).trim()
+
+  if (!reason) return { error: '请填写校正原因' }
+  if (isNaN(newCount) || newCount < 0) return { error: '点赞数必须为非负整数' }
+
+  try {
+    const oldCount = await prisma.like.count({ where: { projectId } })
+
+    // 清除所有旧 likes，按新值插入虚拟记录
+    await prisma.like.deleteMany({ where: { projectId } })
+    if (newCount > 0) {
+      await prisma.like.createMany({
+        data: Array.from({ length: newCount }, (_, i) => ({
+          projectId,
+          fingerprint: `__admin_adj_${i}`,
+        })),
+      })
+    }
+
+    await prisma.likeAdjustLog.create({
+      data: { projectId, oldCount, newCount, reason },
+    })
+
+    revalidatePath('/admin/projects')
+    revalidatePath('/')
+    return {}
+  } catch (e) {
+    return { error: String(e) }
+  }
+}

--- a/src/app/admin/projects/new/page.tsx
+++ b/src/app/admin/projects/new/page.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+import { prisma } from '@/lib/prisma'
+import ProjectForm from '../ProjectForm'
+
+export const metadata: Metadata = { title: '新增项目 · 管理后台' }
+
+export default async function NewProjectPage() {
+  const seasons = await prisma.season.findMany({ orderBy: { createdAt: 'desc' }, select: { id: true, name: true } })
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      <header className="bg-white border-b border-gray-200">
+        <div className="mx-auto max-w-3xl px-4 py-4 flex items-center gap-3 text-sm">
+          <Link href="/admin" className="text-indigo-600 hover:text-indigo-800">← 管理后台</Link>
+          <span className="text-gray-300">/</span>
+          <Link href="/admin/projects" className="text-indigo-600 hover:text-indigo-800">项目管理</Link>
+          <span className="text-gray-300">/</span>
+          <span className="font-semibold text-gray-900">新增项目</span>
+        </div>
+      </header>
+      <div className="mx-auto max-w-3xl px-4 py-8">
+        <h1 className="text-2xl font-extrabold text-gray-900 mb-6">新增项目</h1>
+        <ProjectForm seasons={seasons} />
+      </div>
+    </main>
+  )
+}

--- a/src/app/admin/projects/page.tsx
+++ b/src/app/admin/projects/page.tsx
@@ -1,0 +1,110 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+import { prisma } from '@/lib/prisma'
+import ProjectListActions from './ProjectListActions'
+
+export const metadata: Metadata = { title: '项目管理 · 管理后台' }
+export const dynamic = 'force-dynamic'
+
+export default async function AdminProjectsPage() {
+  const projects = await prisma.project.findMany({
+    orderBy: [{ sortOrder: 'asc' }, { createdAt: 'desc' }],
+    include: {
+      season: { select: { id: true, name: true } },
+      _count: { select: { likes: true, comments: true } },
+    },
+  })
+
+  const AWARD_MAP: Record<string, string> = {
+    UNREPLACEABLE: '🏆 最不可替代',
+    USELESS: '🏅 最没用AI',
+  }
+  const STATUS_MAP: Record<string, { label: string; color: string }> = {
+    CANDIDATE: { label: '候选中', color: 'bg-blue-100 text-blue-700' },
+    WINNER: { label: '获奖', color: 'bg-amber-100 text-amber-700' },
+    LOSER: { label: '未获奖', color: 'bg-gray-100 text-gray-500' },
+  }
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      <header className="bg-white border-b border-gray-200">
+        <div className="mx-auto max-w-6xl px-4 py-4 flex items-center justify-between">
+          <div className="flex items-center gap-3 text-sm">
+            <Link href="/admin" className="text-indigo-600 hover:text-indigo-800 transition">← 管理后台</Link>
+            <span className="text-gray-300">/</span>
+            <span className="font-semibold text-gray-900">项目管理</span>
+          </div>
+          <Link href="/admin/projects/new" className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700 transition">
+            + 新增项目
+          </Link>
+        </div>
+      </header>
+
+      <div className="mx-auto max-w-6xl px-4 py-8">
+        {projects.length === 0 ? (
+          <div className="rounded-2xl border border-dashed border-gray-300 bg-white py-20 text-center text-gray-400">
+            <p className="text-4xl mb-3">📭</p>
+            <p className="text-lg font-medium">暂无项目</p>
+            <Link href="/admin/projects/new" className="mt-4 inline-block text-sm text-indigo-600 hover:underline">添加第一个项目</Link>
+          </div>
+        ) : (
+          <div className="rounded-2xl border border-gray-200 bg-white overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-50 border-b border-gray-200">
+                <tr>
+                  <th className="px-4 py-3 text-left text-gray-600 font-medium">项目名称</th>
+                  <th className="px-4 py-3 text-left text-gray-600 font-medium">届次</th>
+                  <th className="px-4 py-3 text-left text-gray-600 font-medium">奖项</th>
+                  <th className="px-4 py-3 text-left text-gray-600 font-medium">获奖状态</th>
+                  <th className="px-4 py-3 text-center text-gray-600 font-medium">排序</th>
+                  <th className="px-4 py-3 text-center text-gray-600 font-medium">👍</th>
+                  <th className="px-4 py-3 text-center text-gray-600 font-medium">💬</th>
+                  <th className="px-4 py-3 text-left text-gray-600 font-medium">状态</th>
+                  <th className="px-4 py-3 text-left text-gray-600 font-medium">操作</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {projects.map((p) => {
+                  const statusInfo = STATUS_MAP[p.awardStatus] ?? STATUS_MAP.CANDIDATE
+                  return (
+                    <tr key={p.id} className={`hover:bg-gray-50 transition ${!p.isActive ? 'opacity-50' : ''}`}>
+                      <td className="px-4 py-3">
+                        <div>
+                          <p className="font-semibold text-gray-900">{p.name}</p>
+                          <p className="text-xs text-gray-400 font-mono">{p.slug}</p>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 text-gray-600">{p.season.name}</td>
+                      <td className="px-4 py-3 text-gray-600">{p.award ? AWARD_MAP[p.award] ?? p.award : '—'}</td>
+                      <td className="px-4 py-3">
+                        <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${statusInfo.color}`}>
+                          {statusInfo.label}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-center text-gray-500">{p.sortOrder}</td>
+                      <td className="px-4 py-3 text-center text-gray-500">{p._count.likes}</td>
+                      <td className="px-4 py-3 text-center text-gray-500">{p._count.comments}</td>
+                      <td className="px-4 py-3">
+                        <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${p.isActive ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'}`}>
+                          {p.isActive ? '上架' : '已下架'}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <ProjectListActions
+                          id={p.id}
+                          slug={p.slug}
+                          isActive={p.isActive}
+                          likesCount={p._count.likes}
+                        />
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </main>
+  )
+}

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -10,9 +10,12 @@ export type ProjectWithCounts = {
   githubUrl: string | null
   imageUrl: string | null
   award: string | null
+  awardStatus: string
   judgeComment: string | null
   judgeNickname: string | null
   isActive: boolean
+  embedEnabled: boolean
+  sortOrder: number
   seasonId: string
   createdAt: Date
   updatedAt: Date
@@ -43,7 +46,7 @@ export async function getActiveSeason(): Promise<SeasonWithProjects | null> {
         include: {
           _count: { select: { likes: true, comments: true } },
         },
-        orderBy: { createdAt: 'desc' },
+        orderBy: [{ sortOrder: 'asc' }, { createdAt: 'desc' }],
       },
     },
   })


### PR DESCRIPTION
## 变更概述

实现 Issue #10「管理后台 - 项目管理」所有功能需求。

## 实现内容

### 路由
| 路由 | 说明 |
|------|------|
| `/admin/projects` | 项目列表（按 sortOrder + 创建时间排序）|
| `/admin/projects/new` | 新增项目（无需提名流程，支持首届种子录入）|
| `/admin/projects/[id]/edit` | 编辑项目 + 点赞校正日志 |

### 字段管理
所有字段均可编辑：名称、slug、一句话介绍、详细介绍（Markdown）、体验链接、GitHub链接、所属届次、申报奖项、**获奖状态**（候选中/获奖/未获奖）、评委点评+昵称、**展示排序**、**是否内嵌体验**（占位）、是否上架

### 操作
- **下架/上架**：快速切换 isActive，前台立即生效
- **删除**：二次确认弹窗，级联清除 likes/comments/likeAdjustLogs
- **点赞数校正**：弹窗填写新值+必填原因，写入 LikeAdjustLog

### Schema 扩展
```prisma
model Project {
  awardStatus  String  @default("CANDIDATE") // CANDIDATE | WINNER | LOSER
  embedEnabled Boolean @default(false)
  sortOrder    Int     @default(0)
  ...
}

model LikeAdjustLog {
  id        String   @id @default(cuid())
  projectId String
  oldCount  Int
  newCount  Int
  reason    String
  createdAt DateTime @default(now())
}
```

### 前台联动
- 项目列表排序改为 `sortOrder asc, createdAt desc`
- data.ts 类型更新（含新字段）

## 验收清单
- [x] 管理员可直接新增项目（不经提名流程）
- [x] 所有字段可编辑
- [x] 下架后前台不可见（isActive=false → notFound），历届存档保留
- [x] 获奖状态（候选中/获奖/未获奖）正确存储
- [x] 评委点评编辑正常，详情页展示
- [x] 展示排序可调整，前台按序渲染
- [x] 点赞数校正：必填原因，有操作日志（最近 20 条）
- [x] 本地 build 通过 ✅

Closes #10