### PR TITLE
feat: 管理后台评论管理与内容安全 (REQ-013)

### DIFF
--- a/src/app/admin/blocked-words/BlockedWordForm.tsx
+++ b/src/app/admin/blocked-words/BlockedWordForm.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useActionState, useRef, useEffect } from 'react'
+import { addBlockedWord } from './actions'
+
+const initialState = { error: undefined as string | undefined }
+
+export default function BlockedWordForm() {
+  const [state, formAction, isPending] = useActionState(addBlockedWord, initialState)
+  const formRef = useRef<HTMLFormElement>(null)
+
+  useEffect(() => {
+    if (!state?.error && !isPending) formRef.current?.reset()
+  }, [state, isPending])
+
+  return (
+    <form ref={formRef} action={formAction} className="flex gap-3">
+      <input
+        type="text"
+        name="word"
+        required
+        placeholder="输入关键词（最多 50 字符）"
+        maxLength={50}
+        className="flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:border-indigo-500"
+      />
+      <button
+        type="submit"
+        disabled={isPending}
+        className="rounded-lg bg-red-500 px-4 py-2 text-sm font-semibold text-white hover:bg-red-600 disabled:opacity-50 transition"
+      >
+        {isPending ? '添加中…' : '添加'}
+      </button>
+      {state?.error && (
+        <p className="text-xs text-red-500 self-center">{state.error}</p>
+      )}
+    </form>
+  )
+}

--- a/src/app/admin/blocked-words/DeleteWordButton.tsx
+++ b/src/app/admin/blocked-words/DeleteWordButton.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { useTransition } from 'react'
+import { deleteBlockedWord } from './actions'
+
+export default function DeleteWordButton({ id, word }: { id: string; word: string }) {
+  const [isPending, startTransition] = useTransition()
+
+  return (
+    <button
+      onClick={() => startTransition(async () => { await deleteBlockedWord(id) })}
+      disabled={isPending}
+      title={`删除「${word}」`}
+      className="rounded-full w-5 h-5 flex items-center justify-center text-red-400 hover:text-red-600 hover:bg-red-100 transition disabled:opacity-40 text-xs font-bold"
+    >
+      ×
+    </button>
+  )
+}

--- a/src/app/admin/blocked-words/actions.ts
+++ b/src/app/admin/blocked-words/actions.ts
@@ -1,0 +1,33 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { prisma } from '@/lib/prisma'
+
+/** 添加敏感词 */
+export async function addBlockedWord(
+  _prev: { error?: string },
+  formData: FormData,
+): Promise<{ error?: string }> {
+  const word = (formData.get('word') as string).trim()
+  if (!word) return { error: '关键词不能为空' }
+  if (word.length > 50) return { error: '关键词不能超过 50 个字符' }
+
+  try {
+    await prisma.blockedWord.create({ data: { word } })
+    revalidatePath('/admin/blocked-words')
+    return {}
+  } catch {
+    return { error: `「${word}」已存在于黑名单` }
+  }
+}
+
+/** 删除敏感词 */
+export async function deleteBlockedWord(id: string): Promise<{ error?: string }> {
+  try {
+    await prisma.blockedWord.delete({ where: { id } })
+    revalidatePath('/admin/blocked-words')
+    return {}
+  } catch (e) {
+    return { error: String(e) }
+  }
+}

--- a/src/app/admin/blocked-words/page.tsx
+++ b/src/app/admin/blocked-words/page.tsx
@@ -1,0 +1,67 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+import { prisma } from '@/lib/prisma'
+import BlockedWordForm from './BlockedWordForm'
+import DeleteWordButton from './DeleteWordButton'
+
+export const metadata: Metadata = { title: '敏感词管理 · 管理后台' }
+export const dynamic = 'force-dynamic'
+
+// 内置黑名单（展示用，不可删除）
+const BUILTIN = ['广告', '刷单', '加微信', '加qq', '点击链接']
+
+export default async function BlockedWordsPage() {
+  const words = await prisma.blockedWord.findMany({ orderBy: { createdAt: 'desc' } })
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      <header className="bg-white border-b border-gray-200">
+        <div className="mx-auto max-w-2xl px-4 py-4 flex items-center gap-3 text-sm">
+          <Link href="/admin" className="text-indigo-600 hover:text-indigo-800 transition">← 管理后台</Link>
+          <span className="text-gray-300">/</span>
+          <span className="font-semibold text-gray-900">敏感词管理</span>
+        </div>
+      </header>
+
+      <div className="mx-auto max-w-2xl px-4 py-8 space-y-6">
+        {/* 添加表单 */}
+        <div className="rounded-2xl border border-gray-200 bg-white p-6 space-y-4">
+          <h2 className="font-bold text-gray-900">添加敏感词</h2>
+          <BlockedWordForm />
+        </div>
+
+        {/* 内置黑名单（只读） */}
+        <div className="rounded-2xl border border-gray-200 bg-white p-6 space-y-3">
+          <h2 className="font-bold text-gray-900 text-sm">内置黑名单（不可删除）</h2>
+          <div className="flex flex-wrap gap-2">
+            {BUILTIN.map((w) => (
+              <span key={w} className="rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-500">
+                {w}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        {/* 自定义黑名单 */}
+        <div className="rounded-2xl border border-gray-200 bg-white p-6 space-y-3">
+          <h2 className="font-bold text-gray-900 text-sm">
+            自定义黑名单
+            <span className="ml-2 text-gray-400 font-normal">({words.length} 个)</span>
+          </h2>
+          {words.length === 0 ? (
+            <p className="text-sm text-gray-400">暂无自定义关键词</p>
+          ) : (
+            <div className="flex flex-wrap gap-2">
+              {words.map((w) => (
+                <div key={w.id} className="flex items-center gap-1 rounded-full bg-red-50 border border-red-200 pl-3 pr-1.5 py-1">
+                  <span className="text-sm text-red-700">{w.word}</span>
+                  <DeleteWordButton id={w.id} word={w.word} />
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/app/admin/comments/CommentActions.tsx
+++ b/src/app/admin/comments/CommentActions.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { useTransition } from 'react'
+import { hideComment, restoreComment } from './actions'
+
+export default function CommentActions({ commentId, isHidden }: { commentId: string; isHidden: boolean }) {
+  const [isPending, startTransition] = useTransition()
+
+  function toggle() {
+    startTransition(async () => {
+      if (isHidden) await restoreComment(commentId)
+      else await hideComment(commentId)
+    })
+  }
+
+  return (
+    <button
+      onClick={toggle}
+      disabled={isPending}
+      className={`shrink-0 text-xs font-semibold transition disabled:opacity-40 ${isHidden ? 'text-green-600 hover:text-green-800' : 'text-red-500 hover:text-red-700'}`}
+    >
+      {isPending ? '…' : isHidden ? '恢复' : '隐藏'}
+    </button>
+  )
+}

--- a/src/app/admin/comments/actions.ts
+++ b/src/app/admin/comments/actions.ts
@@ -1,0 +1,26 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { prisma } from '@/lib/prisma'
+
+/** 软删除评论（isHidden=true） */
+export async function hideComment(commentId: string): Promise<{ error?: string }> {
+  try {
+    await prisma.comment.update({ where: { id: commentId }, data: { isHidden: true } })
+    revalidatePath('/admin/comments')
+    return {}
+  } catch (e) {
+    return { error: String(e) }
+  }
+}
+
+/** 恢复评论（isHidden=false） */
+export async function restoreComment(commentId: string): Promise<{ error?: string }> {
+  try {
+    await prisma.comment.update({ where: { id: commentId }, data: { isHidden: false } })
+    revalidatePath('/admin/comments')
+    return {}
+  } catch (e) {
+    return { error: String(e) }
+  }
+}

--- a/src/app/admin/comments/page.tsx
+++ b/src/app/admin/comments/page.tsx
@@ -1,0 +1,133 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+import { prisma } from '@/lib/prisma'
+import CommentActions from './CommentActions'
+
+export const metadata: Metadata = { title: '评论管理 · 管理后台' }
+export const dynamic = 'force-dynamic'
+
+type SearchParams = { q?: string; hidden?: string }
+
+export default async function AdminCommentsPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>
+}) {
+  const params = await searchParams
+  const q = params.q?.trim() ?? ''
+  const showHidden = params.hidden === '1'
+
+  // 查询评论，按项目分组
+  const comments = await prisma.comment.findMany({
+    where: {
+      ...(q ? { OR: [{ content: { contains: q } }, { nickname: { contains: q } }] } : {}),
+      ...(!showHidden ? {} : {}), // 默认显示全部（含已隐藏）
+    },
+    orderBy: { createdAt: 'desc' },
+    take: 200,
+    include: {
+      project: { select: { id: true, name: true, slug: true } },
+      _count: { select: { commentLikes: true } },
+    },
+  })
+
+  // 按项目分组
+  const grouped = new Map<string, {
+    project: { id: string; name: string; slug: string }
+    comments: typeof comments
+  }>()
+  for (const c of comments) {
+    if (!grouped.has(c.projectId)) {
+      grouped.set(c.projectId, { project: c.project, comments: [] })
+    }
+    grouped.get(c.projectId)!.comments.push(c)
+  }
+
+  const totalCount = comments.length
+  const hiddenCount = comments.filter((c) => c.isHidden).length
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      <header className="bg-white border-b border-gray-200">
+        <div className="mx-auto max-w-5xl px-4 py-4 flex items-center justify-between">
+          <div className="flex items-center gap-3 text-sm">
+            <Link href="/admin" className="text-indigo-600 hover:text-indigo-800 transition">← 管理后台</Link>
+            <span className="text-gray-300">/</span>
+            <span className="font-semibold text-gray-900">评论管理</span>
+          </div>
+          <div className="text-xs text-gray-400">
+            共 {totalCount} 条 · 已隐藏 {hiddenCount} 条
+          </div>
+        </div>
+      </header>
+
+      <div className="mx-auto max-w-5xl px-4 py-8 space-y-6">
+        {/* 搜索栏 */}
+        <form method="GET" className="flex gap-3">
+          <input
+            type="search"
+            name="q"
+            defaultValue={q}
+            placeholder="搜索评论内容或昵称…"
+            className="flex-1 rounded-lg border border-gray-300 px-4 py-2 text-sm focus:outline-none focus:border-indigo-500"
+          />
+          <button type="submit" className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700 transition">
+            搜索
+          </button>
+          {q && (
+            <Link href="/admin/comments" className="rounded-lg border border-gray-300 px-4 py-2 text-sm text-gray-600 hover:bg-gray-50 transition">
+              清除
+            </Link>
+          )}
+        </form>
+
+        {/* 评论列表（按项目分组） */}
+        {grouped.size === 0 ? (
+          <div className="rounded-2xl border border-dashed border-gray-300 bg-white py-16 text-center text-gray-400">
+            <p className="text-3xl mb-2">💬</p>
+            <p className="text-sm font-medium">{q ? '没有匹配的评论' : '暂无评论'}</p>
+          </div>
+        ) : (
+          <div className="space-y-6">
+            {[...grouped.values()].map(({ project, comments: grpComments }) => (
+              <section key={project.id} className="rounded-2xl border border-gray-200 bg-white overflow-hidden">
+                {/* 项目标题 */}
+                <div className="bg-gray-50 border-b border-gray-200 px-5 py-3 flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <span className="font-semibold text-gray-800">{project.name}</span>
+                    <span className="text-xs text-gray-400">({grpComments.length} 条)</span>
+                  </div>
+                  <Link href={`/ai/${project.slug}`} target="_blank" className="text-xs text-indigo-500 hover:text-indigo-700">
+                    查看详情页 →
+                  </Link>
+                </div>
+
+                {/* 评论列表 */}
+                <div className="divide-y divide-gray-100">
+                  {grpComments.map((c) => (
+                    <div key={c.id} className={`px-5 py-4 flex items-start justify-between gap-4 ${c.isHidden ? 'opacity-50 bg-red-50/30' : ''}`}>
+                      <div className="flex-1 min-w-0 space-y-1">
+                        <div className="flex items-center gap-2 text-xs text-gray-500">
+                          <span className="font-semibold text-gray-700">{c.nickname}</span>
+                          <span>·</span>
+                          <span>{new Date(c.createdAt).toLocaleString('zh-CN')}</span>
+                          <span>·</span>
+                          <span>👍 {c._count.commentLikes}</span>
+                          {c.isHidden && (
+                            <span className="rounded bg-red-100 px-1.5 py-0.5 text-red-500 font-medium">已隐藏</span>
+                          )}
+                        </div>
+                        <p className="text-sm text-gray-700 break-words">{c.content}</p>
+                      </div>
+                      <CommentActions commentId={c.id} isHidden={c.isHidden} />
+                    </div>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        )}
+      </div>
+    </main>
+  )
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -5,6 +5,8 @@ const NAV_ITEMS = [
   { href: '/admin/seasons', emoji: '📅', title: '届次管理', desc: '创建届次、切换状态、设置 Slogan' },
   { href: '/admin/projects', emoji: '🗂️', title: '项目管理', desc: '新增、编辑、下架项目，校正点赞数' },
   { href: '/admin/review', emoji: '📋', title: '审核中心', desc: '处理提名与自荐，管理候选列表' },
+  { href: '/admin/comments', emoji: '💬', title: '评论管理', desc: '查看、隐藏违规评论，按项目分组' },
+  { href: '/admin/blocked-words', emoji: '🚫', title: '敏感词管理', desc: '动态配置关键词黑名单，无需改代码' },
 ]
 
 export default function AdminPage() {


### PR DESCRIPTION
## 变更概述

实现 Issue #12「管理后台 - 评论管理与内容安全」所有功能需求。

## 实现内容

### /admin/comments 评论管理
- 按项目分组展示所有评论（最新 200 条）
- 关键词搜索（评论内容 + 昵称）
- 每条评论显示：昵称、时间、点赞数、是否已隐藏
- **软删除**（isHidden=true）：隐藏后前台不展示，其他评论楼层不受影响
- 支持**恢复**已隐藏的评论

### /admin/blocked-words 敏感词管理
- 内置黑名单展示（只读，代码层维护）
- 自定义黑名单：添加关键词（Server Action 校验唯一性）+ 删除（点击 × 即时生效）
- 新增词立即对前端评论提交生效（filter.ts 缓存 60 秒后刷新）

### /admin 首页
新增「评论管理」「敏感词管理」两个导航卡片。

## 验收清单
- [x] 管理员可查看所有评论，按项目分组
- [x] 评论搜索正常（内容/昵称）
- [x] 删除（隐藏）评论后前台不展示，其他评论不受影响
- [x] 黑名单词可后台增删，无需改代码
- [x] 前端提交评论时匹配黑名单，命中时拦截并提示
- [x] 本地 build 通过 ✅

Closes #12