### PR TITLE
feat: 提名功能 (REQ-008)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -71,6 +71,7 @@ model Submission {
   projectName        String
   projectUrl         String
   description        String
+  recommendReason    String?  // 推荐理由（为什么值得上榜）
   awardCategory      String?  // UNREPLACEABLE | USELESS | null（申报奖项）
   submitterEmail     String?
   submitterNickname  String?  // 自荐人昵称

--- a/src/app/admin/review/ReviewTable.tsx
+++ b/src/app/admin/review/ReviewTable.tsx
@@ -16,6 +16,7 @@ type Submission = {
   projectName: string
   projectUrl: string
   description: string
+  recommendReason: string | null
   awardCategory: string | null
   submitterEmail: string | null
   submitterNickname: string | null
@@ -236,6 +237,7 @@ export default function ReviewTable({ submissions }: { submissions: Submission[]
                 <a href={preview.projectUrl} target="_blank" rel="noopener noreferrer" className="text-indigo-600 hover:underline break-all">{preview.projectUrl}</a>
               </p>
               <p><span className="font-medium text-gray-500">介绍：</span>{preview.description}</p>
+                      {preview.recommendReason && <p><span className="font-medium text-gray-500">推荐理由：</span>{preview.recommendReason}</p>}
               {preview.submitterNickname && <p><span className="font-medium text-gray-500">提交者：</span>{preview.submitterNickname}</p>}
               {preview.submitterEmail && <p><span className="font-medium text-gray-500">邮箱：</span>{preview.submitterEmail}</p>}
               {preview.rejectNote && <p><span className="font-medium text-gray-500">拒绝备注：</span>{preview.rejectNote}</p>}

--- a/src/app/api/submit/route.ts
+++ b/src/app/api/submit/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+/** POST /api/submit — 提名或自荐 */
+export async function POST(request: NextRequest) {
+  let body: Record<string, string>
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: '请求格式错误' }, { status: 400 })
+  }
+
+  // Honeypot：机器人会填 _trap，真实用户不会
+  if (body._trap) {
+    return NextResponse.json({ ok: true }) // 静默丢弃
+  }
+
+  const type = body.type === 'SELF' ? 'SELF' : 'NOMINATION'
+  const projectName = (body.projectName ?? '').trim()
+  const projectUrl = (body.projectUrl ?? '').trim()
+  const description = (body.description ?? '').trim()
+  const recommendReason = (body.recommendReason ?? '').trim() || null
+  const awardCategory = body.awardCategory || null
+  const submitterNickname = (body.submitterNickname ?? '').trim() || null
+  const submitterEmail = (body.submitterEmail ?? '').trim() || null
+
+  // 必填校验
+  if (!projectName || projectName.length > 100) {
+    return NextResponse.json({ error: 'AI 名称不能为空（最长 100 字）' }, { status: 400 })
+  }
+  if (!projectUrl) {
+    return NextResponse.json({ error: '体验链接不能为空' }, { status: 400 })
+  }
+  // URL 格式校验
+  try {
+    const u = new URL(projectUrl)
+    if (!['http:', 'https:'].includes(u.protocol)) throw new Error()
+  } catch {
+    return NextResponse.json({ error: 'URL 格式不合法，请填写完整的 http/https 链接' }, { status: 400 })
+  }
+  if (!description || description.length < 50) {
+    return NextResponse.json({ error: '详细介绍至少需要 50 个字' }, { status: 400 })
+  }
+  if (description.length > 500) {
+    return NextResponse.json({ error: '详细介绍不能超过 500 个字' }, { status: 400 })
+  }
+  if (!awardCategory || !['UNREPLACEABLE', 'USELESS'].includes(awardCategory)) {
+    return NextResponse.json({ error: '请选择申报奖项' }, { status: 400 })
+  }
+
+  // 获取当前活跃届次
+  const season = await prisma.season.findFirst({
+    where: { status: { in: ['ACTIVE', 'AWARDING', 'UPCOMING'] } },
+    orderBy: [{ status: 'asc' }, { createdAt: 'desc' }],
+  })
+  if (!season) {
+    return NextResponse.json({ error: '当前暂无开放中的届次，请稍后再试' }, { status: 400 })
+  }
+
+  // 重复 URL 检测（同届次已有相同 projectUrl 的 PENDING/APPROVED 提交）
+  const existing = await prisma.submission.findFirst({
+    where: {
+      projectUrl,
+      seasonId: season.id,
+      status: { in: ['PENDING', 'APPROVED'] },
+    },
+  })
+  if (existing) {
+    return NextResponse.json({ error: '该项目已存在或正在审核中，感谢你的热心！' }, { status: 409 })
+  }
+
+  await prisma.submission.create({
+    data: {
+      type,
+      projectName,
+      projectUrl,
+      description,
+      recommendReason,
+      awardCategory,
+      submitterNickname,
+      submitterEmail,
+      seasonId: season.id,
+    },
+  })
+
+  return NextResponse.json({ ok: true }, { status: 201 })
+}

--- a/src/app/submit/page.tsx
+++ b/src/app/submit/page.tsx
@@ -1,9 +1,207 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import Link from 'next/link'
+import { useSearchParams } from 'next/navigation'
+import { Suspense } from 'react'
+
+function SubmitForm() {
+  const searchParams = useSearchParams()
+  const defaultType = searchParams.get('type') === 'self' ? 'SELF' : 'NOMINATION'
+
+  const [type, setType] = useState<'NOMINATION' | 'SELF'>(defaultType as 'NOMINATION' | 'SELF')
+  const [form, setForm] = useState({
+    projectName: '',
+    projectUrl: '',
+    description: '',
+    recommendReason: '',
+    awardCategory: '',
+    submitterNickname: '',
+    submitterEmail: '',
+    _trap: '', // honeypot
+  })
+  const [urlError, setUrlError] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState(false)
+
+  // 实时 URL 格式校验
+  useEffect(() => {
+    if (!form.projectUrl) { setUrlError(''); return }
+    try {
+      const u = new URL(form.projectUrl)
+      if (!['http:', 'https:'].includes(u.protocol)) throw new Error()
+      setUrlError('')
+    } catch {
+      setUrlError('请填写完整的 http/https 链接')
+    }
+  }, [form.projectUrl])
+
+  function set(field: string, value: string) {
+    setForm((prev) => ({ ...prev, [field]: value }))
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError('')
+    if (urlError) return
+    setSubmitting(true)
+    try {
+      const res = await fetch('/api/submit', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...form, type }),
+      })
+      const data = await res.json()
+      if (!res.ok) { setError(data.error ?? '提交失败，请重试'); return }
+      setSuccess(true)
+    } catch {
+      setError('网络错误，请重试')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (success) {
+    return (
+      <div className="text-center py-16 space-y-4">
+        <p className="text-5xl">🎉</p>
+        <h2 className="text-2xl font-extrabold text-gray-900">提交成功！</h2>
+        <p className="text-gray-500">感谢你的{type === 'SELF' ? '自荐' : '提名'}，我们会尽快审核。</p>
+        <div className="flex flex-col sm:flex-row gap-3 justify-center pt-4">
+          <button onClick={() => { setSuccess(false); setForm({ projectName: '', projectUrl: '', description: '', recommendReason: '', awardCategory: '', submitterNickname: '', submitterEmail: '', _trap: '' }) }}
+            className="rounded-full border border-indigo-300 px-6 py-2.5 text-sm font-semibold text-indigo-700 hover:bg-indigo-50 transition">
+            再提名一个
+          </button>
+          <Link href="/" className="rounded-full bg-indigo-600 px-6 py-2.5 text-sm font-semibold text-white hover:bg-indigo-700 transition text-center">
+            返回首页
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      {/* Honeypot（隐藏字段，机器人会填） */}
+      <input type="text" name="_trap" value={form._trap} onChange={(e) => set('_trap', e.target.value)}
+        style={{ display: 'none' }} tabIndex={-1} autoComplete="off" aria-hidden="true" />
+
+      {/* 提名 / 自荐切换 */}
+      <div className="flex rounded-xl border border-gray-200 overflow-hidden text-sm">
+        {(['NOMINATION', 'SELF'] as const).map((t) => (
+          <button key={t} type="button" onClick={() => setType(t)}
+            className={`flex-1 py-2.5 font-semibold transition ${type === t ? 'bg-indigo-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}>
+            {t === 'NOMINATION' ? '🙋 提名一个 AI' : '✉️ 我要自荐'}
+          </button>
+        ))}
+      </div>
+
+      {/* AI 名称 */}
+      <Field label="AI 名称" required>
+        <input type="text" maxLength={100} required value={form.projectName} onChange={(e) => set('projectName', e.target.value)}
+          placeholder="例如：Krita AI" className={INPUT} />
+      </Field>
+
+      {/* 体验链接 */}
+      <Field label="体验 / 详情链接" required error={urlError}>
+        <input type="url" required value={form.projectUrl} onChange={(e) => set('projectUrl', e.target.value)}
+          placeholder="https://..." className={`${INPUT} ${urlError ? 'border-red-400' : ''}`} />
+      </Field>
+
+      {/* 一句话介绍（description 字段）*/}
+      <Field label="一句话介绍" required hint="最长 100 字">
+        <input type="text" maxLength={100} required value={form.description.length <= 100 ? form.description : form.description.slice(0, 100)}
+          onChange={(e) => set('description', e.target.value)}
+          placeholder="用一句话描述这个 AI" className={INPUT} />
+      </Field>
+
+      {/* 详细介绍 */}
+      <Field label="详细介绍" required hint={`${form.description.length > 100 ? (form.recommendReason ?? form.description).length : 0}/500（至少 50 字）`}>
+        <textarea rows={4} required
+          value={form.recommendReason}
+          onChange={(e) => set('recommendReason', e.target.value)}
+          placeholder="详细说明这个 AI 的功能、特点，以及为什么它符合「反内卷」精神（至少 50 字）"
+          className={INPUT + ' resize-y'} />
+        <p className="mt-1 text-xs text-gray-400">{form.recommendReason.length}/500</p>
+      </Field>
+
+      {/* 申报奖项 */}
+      <Field label="申报奖项" required>
+        <div className="flex flex-col sm:flex-row gap-3">
+          {[
+            { value: 'UNREPLACEABLE', label: '🏆 最不可替代奖', desc: '增强人、扩展人的 AI' },
+            { value: 'USELESS', label: '🏅 最没用AI奖', desc: '完全无用但充满创意' },
+          ].map((opt) => (
+            <label key={opt.value}
+              className={`flex-1 cursor-pointer rounded-xl border p-4 transition ${form.awardCategory === opt.value ? 'border-indigo-500 bg-indigo-50' : 'border-gray-200 hover:border-indigo-300'}`}>
+              <input type="radio" name="awardCategory" value={opt.value} checked={form.awardCategory === opt.value}
+                onChange={() => set('awardCategory', opt.value)} className="sr-only" />
+              <p className="font-semibold text-sm text-gray-900">{opt.label}</p>
+              <p className="text-xs text-gray-500 mt-0.5">{opt.desc}</p>
+            </label>
+          ))}
+        </div>
+      </Field>
+
+      {/* 选填信息 */}
+      <div className="rounded-xl border border-gray-200 bg-gray-50 p-5 space-y-4">
+        <p className="text-sm font-medium text-gray-600">选填信息（不对外公开）</p>
+        <Field label={type === 'SELF' ? '你的昵称' : '提名人昵称'} hint="默认「匿名」">
+          <input type="text" maxLength={30} value={form.submitterNickname} onChange={(e) => set('submitterNickname', e.target.value)}
+            placeholder="留空则显示「匿名」" className={INPUT} />
+        </Field>
+        <Field label="联系方式" hint="方便我们追问，不对外展示">
+          <input type="text" maxLength={100} value={form.submitterEmail} onChange={(e) => set('submitterEmail', e.target.value)}
+            placeholder="邮箱 / 微信 / Twitter 等均可" className={INPUT} />
+        </Field>
+      </div>
+
+      {error && <p className="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-600">{error}</p>}
+
+      <button type="submit" disabled={submitting || !!urlError}
+        className="w-full rounded-xl bg-indigo-600 py-3 text-sm font-semibold text-white hover:bg-indigo-700 disabled:opacity-50 transition">
+        {submitting ? '提交中…' : type === 'SELF' ? '提交自荐' : '提交提名'}
+      </button>
+
+      <p className="text-center text-xs text-gray-400">
+        提交后进入审核队列，通过后将出现在候选列表中
+      </p>
+    </form>
+  )
+}
+
+const INPUT = 'w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:border-indigo-500'
+
+function Field({ label, required, hint, error, children }: {
+  label: string; required?: boolean; hint?: string; error?: string; children: React.ReactNode
+}) {
+  return (
+    <div>
+      <label className="block text-sm font-medium text-gray-700 mb-1">
+        {label}{required && <span className="text-red-500 ml-0.5">*</span>}
+        {hint && <span className="ml-1 text-xs font-normal text-gray-400">{hint}</span>}
+      </label>
+      {children}
+      {error && <p className="mt-1 text-xs text-red-500">{error}</p>}
+    </div>
+  )
+}
+
 export default function SubmitPage() {
   return (
-    <main className="min-h-screen bg-gray-50 flex items-center justify-center">
-      <div className="text-center text-gray-400">
-        <p className="text-4xl mb-3">✉️</p>
-        <p className="text-lg font-medium">提名/自荐功能开发中</p>
+    <main className="min-h-screen bg-gray-50">
+      <div className="border-b border-gray-200 bg-white">
+        <div className="mx-auto max-w-2xl px-4 py-3">
+          <Link href="/" className="text-sm text-indigo-600 hover:text-indigo-800 transition">← 返回首页</Link>
+        </div>
+      </div>
+      <div className="mx-auto max-w-2xl px-4 py-10">
+        <h1 className="text-2xl font-extrabold text-gray-900 mb-2">提名 / 自荐一个 AI</h1>
+        <p className="text-gray-500 text-sm mb-8">发现了好 AI？告诉我们，一起推上榜单。</p>
+        <Suspense fallback={<div className="text-center text-gray-400 py-10">加载中…</div>}>
+          <SubmitForm />
+        </Suspense>
       </div>
     </main>
   )


### PR DESCRIPTION
## 变更概述

实现 Issue #7「提名功能」所有功能需求。

## 实现内容

### /submit 表单页（Client Component）
- **提名/自荐切换**：tab 切换，支持 `?type=self` URL 参数直达自荐模式
- **字段**：
  - AI 名称（必填，100 字）
  - 体验/详情链接（必填，实时 URL 格式校验）
  - 一句话介绍（必填，100 字）
  - 详细介绍（必填，50~500 字，字数计数）
  - 申报奖项（必填，卡片式单选，带说明文字）
  - 昵称（选填，默认匿名）
  - 联系方式（选填，不对外展示）
- **Honeypot**：隐藏 `_trap` 字段，机器人填写则静默丢弃
- **成功状态**：显示确认界面，可继续提名

### /api/submit（POST Route）
- 必填字段校验
- URL 格式校验（server 端）
- Honeypot 静默丢弃
- 重复 URL 检测（同届次 PENDING/APPROVED 提交已存在 → 409）
- 自动关联当前活跃届次（AWARDING > ACTIVE > UPCOMING 优先级）

### Schema 扩展
```prisma
model Submission {
  recommendReason String? // 推荐理由
}
```

### 联动
- 审核中心预览弹窗新增「推荐理由」字段展示

## 验收清单
- [x] 表单字段完整，必填校验有效
- [x] URL 格式实时校验（前端）+ server 端校验
- [x] 提交成功后有明确提示（「提交成功！感谢你的提名」）
- [x] 数据进入管理后台待审队列（type=NOMINATION/SELF，status=PENDING）
- [x] Honeypot 防机器人生效（静默丢弃）
- [x] 联系方式不在前台展示
- [x] 重复 URL 提示「该项目已存在或正在审核中」
- [x] 本地 build 通过 ✅

Closes #7