### PR TITLE
feat: AI 自荐功能 (REQ-009)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -72,9 +72,11 @@ model Submission {
   projectUrl         String
   description        String
   recommendReason    String?  // 推荐理由（为什么值得上榜）
+  creativeReason     String?  // 创意说明（自荐专属：为什么做它、有什么不同）
+  githubUrl          String?  // 官网/GitHub（自荐专属，可选）
   awardCategory      String?  // UNREPLACEABLE | USELESS | null（申报奖项）
   submitterEmail     String?
-  submitterNickname  String?  // 自荐人昵称
+  submitterNickname  String?  // 自荐人昵称（自荐时公开展示）
   isPublic           Boolean  @default(false) // 是否公开自荐人信息
   status             String   @default("PENDING") // PENDING | APPROVED | REJECTED
   rejectNote         String?  // 拒绝备注（内部，不对外展示）

--- a/src/app/api/submit/route.ts
+++ b/src/app/api/submit/route.ts
@@ -16,15 +16,20 @@ export async function POST(request: NextRequest) {
   }
 
   const type = body.type === 'SELF' ? 'SELF' : 'NOMINATION'
+  const isSelf = type === 'SELF'
+
   const projectName = (body.projectName ?? '').trim()
   const projectUrl = (body.projectUrl ?? '').trim()
   const description = (body.description ?? '').trim()
   const recommendReason = (body.recommendReason ?? '').trim() || null
+  const creativeReason = (body.creativeReason ?? '').trim() || null
   const awardCategory = body.awardCategory || null
   const submitterNickname = (body.submitterNickname ?? '').trim() || null
   const submitterEmail = (body.submitterEmail ?? '').trim() || null
+  const githubUrl = (body.githubUrl ?? '').trim() || null
+  const isPublic = body.isPublic === 'true'
 
-  // 必填校验
+  // ── 通用必填校验 ──
   if (!projectName || projectName.length > 100) {
     return NextResponse.json({ error: 'AI 名称不能为空（最长 100 字）' }, { status: 400 })
   }
@@ -38,14 +43,49 @@ export async function POST(request: NextRequest) {
   } catch {
     return NextResponse.json({ error: 'URL 格式不合法，请填写完整的 http/https 链接' }, { status: 400 })
   }
-  if (!description || description.length < 50) {
-    return NextResponse.json({ error: '详细介绍至少需要 50 个字' }, { status: 400 })
-  }
-  if (description.length > 500) {
-    return NextResponse.json({ error: '详细介绍不能超过 500 个字' }, { status: 400 })
-  }
   if (!awardCategory || !['UNREPLACEABLE', 'USELESS'].includes(awardCategory)) {
     return NextResponse.json({ error: '请选择申报奖项' }, { status: 400 })
+  }
+
+  if (isSelf) {
+    // ── 自荐专属校验 ──
+    if (!submitterNickname) {
+      return NextResponse.json({ error: '自荐需要填写作者昵称' }, { status: 400 })
+    }
+    if (!submitterEmail) {
+      return NextResponse.json({ error: '自荐需要填写联系邮箱' }, { status: 400 })
+    }
+    // 详细介绍：100~1000 字
+    if (!description || description.length < 100) {
+      return NextResponse.json({ error: '详细介绍至少需要 100 个字' }, { status: 400 })
+    }
+    if (description.length > 1000) {
+      return NextResponse.json({ error: '详细介绍不能超过 1000 个字' }, { status: 400 })
+    }
+    // 创意说明：50~300 字
+    if (!creativeReason || creativeReason.length < 50) {
+      return NextResponse.json({ error: '创意说明至少需要 50 个字' }, { status: 400 })
+    }
+    if (creativeReason.length > 300) {
+      return NextResponse.json({ error: '创意说明不能超过 300 个字' }, { status: 400 })
+    }
+    // githubUrl 格式（若填写）
+    if (githubUrl) {
+      try {
+        const u = new URL(githubUrl)
+        if (!['http:', 'https:'].includes(u.protocol)) throw new Error()
+      } catch {
+        return NextResponse.json({ error: '官网/GitHub 链接格式不合法' }, { status: 400 })
+      }
+    }
+  } else {
+    // ── 提名校验 ──
+    if (!description || description.length < 50) {
+      return NextResponse.json({ error: '详细介绍至少需要 50 个字' }, { status: 400 })
+    }
+    if (description.length > 500) {
+      return NextResponse.json({ error: '详细介绍不能超过 500 个字' }, { status: 400 })
+    }
   }
 
   // 获取当前活跃届次
@@ -57,13 +97,9 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: '当前暂无开放中的届次，请稍后再试' }, { status: 400 })
   }
 
-  // 重复 URL 检测（同届次已有相同 projectUrl 的 PENDING/APPROVED 提交）
+  // 重复 URL 检测
   const existing = await prisma.submission.findFirst({
-    where: {
-      projectUrl,
-      seasonId: season.id,
-      status: { in: ['PENDING', 'APPROVED'] },
-    },
+    where: { projectUrl, seasonId: season.id, status: { in: ['PENDING', 'APPROVED'] } },
   })
   if (existing) {
     return NextResponse.json({ error: '该项目已存在或正在审核中，感谢你的热心！' }, { status: 409 })
@@ -76,9 +112,12 @@ export async function POST(request: NextRequest) {
       projectUrl,
       description,
       recommendReason,
+      creativeReason,
       awardCategory,
       submitterNickname,
       submitterEmail,
+      githubUrl,
+      isPublic,
       seasonId: season.id,
     },
   })

--- a/src/app/submit/page.tsx
+++ b/src/app/submit/page.tsx
@@ -10,22 +10,29 @@ function SubmitForm() {
   const defaultType = searchParams.get('type') === 'self' ? 'SELF' : 'NOMINATION'
 
   const [type, setType] = useState<'NOMINATION' | 'SELF'>(defaultType as 'NOMINATION' | 'SELF')
+  const isSelf = type === 'SELF'
+
   const [form, setForm] = useState({
     projectName: '',
     projectUrl: '',
     description: '',
-    recommendReason: '',
+    recommendReason: '',    // 提名：推荐理由
+    creativeReason: '',     // 自荐：创意说明
     awardCategory: '',
     submitterNickname: '',
     submitterEmail: '',
-    _trap: '', // honeypot
+    githubUrl: '',          // 自荐：官网/GitHub（选填）
+    isPublic: 'false',      // 自荐：是否公开作者信息
+    _trap: '',              // honeypot
   })
+
   const [urlError, setUrlError] = useState('')
+  const [githubUrlError, setGithubUrlError] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
   const [success, setSuccess] = useState(false)
 
-  // 实时 URL 格式校验
+  // 实时 URL 格式校验（体验链接）
   useEffect(() => {
     if (!form.projectUrl) { setUrlError(''); return }
     try {
@@ -37,14 +44,32 @@ function SubmitForm() {
     }
   }, [form.projectUrl])
 
+  // 实时 URL 格式校验（GitHub/官网，选填）
+  useEffect(() => {
+    if (!form.githubUrl) { setGithubUrlError(''); return }
+    try {
+      const u = new URL(form.githubUrl)
+      if (!['http:', 'https:'].includes(u.protocol)) throw new Error()
+      setGithubUrlError('')
+    } catch {
+      setGithubUrlError('请填写完整的 http/https 链接')
+    }
+  }, [form.githubUrl])
+
   function set(field: string, value: string) {
     setForm((prev) => ({ ...prev, [field]: value }))
+  }
+
+  function resetForm() {
+    setForm({ projectName: '', projectUrl: '', description: '', recommendReason: '', creativeReason: '', awardCategory: '', submitterNickname: '', submitterEmail: '', githubUrl: '', isPublic: 'false', _trap: '' })
+    setError('')
+    setSuccess(false)
   }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     setError('')
-    if (urlError) return
+    if (urlError || githubUrlError) return
     setSubmitting(true)
     try {
       const res = await fetch('/api/submit', {
@@ -67,9 +92,9 @@ function SubmitForm() {
       <div className="text-center py-16 space-y-4">
         <p className="text-5xl">🎉</p>
         <h2 className="text-2xl font-extrabold text-gray-900">提交成功！</h2>
-        <p className="text-gray-500">感谢你的{type === 'SELF' ? '自荐' : '提名'}，我们会尽快审核。</p>
+        <p className="text-gray-500">感谢你的{isSelf ? '自荐' : '提名'}，我们会尽快审核。</p>
         <div className="flex flex-col sm:flex-row gap-3 justify-center pt-4">
-          <button onClick={() => { setSuccess(false); setForm({ projectName: '', projectUrl: '', description: '', recommendReason: '', awardCategory: '', submitterNickname: '', submitterEmail: '', _trap: '' }) }}
+          <button onClick={resetForm}
             className="rounded-full border border-indigo-300 px-6 py-2.5 text-sm font-semibold text-indigo-700 hover:bg-indigo-50 transition">
             再提名一个
           </button>
@@ -83,7 +108,7 @@ function SubmitForm() {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
-      {/* Honeypot（隐藏字段，机器人会填） */}
+      {/* Honeypot（隐藏字段） */}
       <input type="text" name="_trap" value={form._trap} onChange={(e) => set('_trap', e.target.value)}
         style={{ display: 'none' }} tabIndex={-1} autoComplete="off" aria-hidden="true" />
 
@@ -109,22 +134,37 @@ function SubmitForm() {
           placeholder="https://..." className={`${INPUT} ${urlError ? 'border-red-400' : ''}`} />
       </Field>
 
-      {/* 一句话介绍（description 字段）*/}
+      {/* 一句话介绍 */}
       <Field label="一句话介绍" required hint="最长 100 字">
         <input type="text" maxLength={100} required value={form.description.length <= 100 ? form.description : form.description.slice(0, 100)}
           onChange={(e) => set('description', e.target.value)}
           placeholder="用一句话描述这个 AI" className={INPUT} />
       </Field>
 
-      {/* 详细介绍 */}
-      <Field label="详细介绍" required hint={`${form.description.length > 100 ? (form.recommendReason ?? form.description).length : 0}/500（至少 50 字）`}>
-        <textarea rows={4} required
+      {/* 详细介绍（自荐：100~1000字 + Markdown；提名：50~500字） */}
+      <Field label="详细介绍" required
+        hint={isSelf ? `${form.recommendReason.length}/1000（至少 100 字，支持 Markdown）` : `${form.recommendReason.length}/500（至少 50 字）`}>
+        <textarea rows={isSelf ? 6 : 4} required
           value={form.recommendReason}
           onChange={(e) => set('recommendReason', e.target.value)}
-          placeholder="详细说明这个 AI 的功能、特点，以及为什么它符合「反内卷」精神（至少 50 字）"
+          placeholder={isSelf
+            ? '详细说明这个 AI 的功能、特点，以及它如何体现「反内卷」精神（至少 100 字，支持 Markdown）'
+            : '详细说明这个 AI 的功能、特点，以及为什么它符合「反内卷」精神（至少 50 字）'}
           className={INPUT + ' resize-y'} />
-        <p className="mt-1 text-xs text-gray-400">{form.recommendReason.length}/500</p>
+        <p className="mt-1 text-xs text-gray-400">{form.recommendReason.length}/{isSelf ? 1000 : 500}</p>
       </Field>
+
+      {/* 自荐专属：创意说明 */}
+      {isSelf && (
+        <Field label="创意说明" required hint={`${form.creativeReason.length}/300（至少 50 字）`}>
+          <textarea rows={3} required
+            value={form.creativeReason}
+            onChange={(e) => set('creativeReason', e.target.value)}
+            placeholder="为什么做这个 AI？它与市面上其他产品有什么不同？"
+            className={INPUT + ' resize-y'} />
+          <p className="mt-1 text-xs text-gray-400">{form.creativeReason.length}/300</p>
+        </Field>
+      )}
 
       {/* 申报奖项 */}
       <Field label="申报奖项" required>
@@ -144,24 +184,52 @@ function SubmitForm() {
         </div>
       </Field>
 
-      {/* 选填信息 */}
-      <div className="rounded-xl border border-gray-200 bg-gray-50 p-5 space-y-4">
-        <p className="text-sm font-medium text-gray-600">选填信息（不对外公开）</p>
-        <Field label={type === 'SELF' ? '你的昵称' : '提名人昵称'} hint="默认「匿名」">
-          <input type="text" maxLength={30} value={form.submitterNickname} onChange={(e) => set('submitterNickname', e.target.value)}
-            placeholder="留空则显示「匿名」" className={INPUT} />
+      {/* 选填 / 自荐必填信息 */}
+      <div className={`rounded-xl border p-5 space-y-4 ${isSelf ? 'border-indigo-200 bg-indigo-50' : 'border-gray-200 bg-gray-50'}`}>
+        <p className="text-sm font-medium text-gray-600">
+          {isSelf ? '作者信息' : '选填信息（不对外公开）'}
+        </p>
+
+        <Field label={isSelf ? '作者昵称' : '提名人昵称'} required={isSelf} hint={!isSelf ? '默认「匿名」' : undefined}>
+          <input type="text" maxLength={30} required={isSelf}
+            value={form.submitterNickname} onChange={(e) => set('submitterNickname', e.target.value)}
+            placeholder={isSelf ? '公开展示用' : '留空则显示「匿名」'} className={INPUT} />
         </Field>
-        <Field label="联系方式" hint="方便我们追问，不对外展示">
-          <input type="text" maxLength={100} value={form.submitterEmail} onChange={(e) => set('submitterEmail', e.target.value)}
-            placeholder="邮箱 / 微信 / Twitter 等均可" className={INPUT} />
+
+        <Field label={isSelf ? '联系邮箱' : '联系方式'} required={isSelf} hint={!isSelf ? '方便我们追问，不对外展示' : '不对外展示'}>
+          <input type={isSelf ? 'email' : 'text'} maxLength={100} required={isSelf}
+            value={form.submitterEmail} onChange={(e) => set('submitterEmail', e.target.value)}
+            placeholder={isSelf ? 'your@email.com' : '邮箱 / 微信 / Twitter 等均可'} className={INPUT} />
         </Field>
+
+        {/* 自荐专属：官网/GitHub */}
+        {isSelf && (
+          <Field label="官网 / GitHub 链接" hint="选填" error={githubUrlError}>
+            <input type="url" value={form.githubUrl} onChange={(e) => set('githubUrl', e.target.value)}
+              placeholder="https://github.com/..." className={`${INPUT} ${githubUrlError ? 'border-red-400' : ''}`} />
+          </Field>
+        )}
+
+        {/* 自荐专属：是否公开作者信息 */}
+        {isSelf && (
+          <label className="flex items-start gap-3 cursor-pointer">
+            <input type="checkbox" checked={form.isPublic === 'true'}
+              onChange={(e) => set('isPublic', e.target.checked ? 'true' : 'false')}
+              className="mt-0.5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500" />
+            <span className="text-sm text-gray-700">
+              <span className="font-medium">同意公开作者信息</span>
+              <br />
+              <span className="text-gray-400">勾选后，项目详情页将展示「作者自荐」标签和你的昵称</span>
+            </span>
+          </label>
+        )}
       </div>
 
       {error && <p className="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-600">{error}</p>}
 
-      <button type="submit" disabled={submitting || !!urlError}
+      <button type="submit" disabled={submitting || !!urlError || !!githubUrlError}
         className="w-full rounded-xl bg-indigo-600 py-3 text-sm font-semibold text-white hover:bg-indigo-700 disabled:opacity-50 transition">
-        {submitting ? '提交中…' : type === 'SELF' ? '提交自荐' : '提交提名'}
+        {submitting ? '提交中…' : isSelf ? '提交自荐' : '提交提名'}
       </button>
 
       <p className="text-center text-xs text-gray-400">


### PR DESCRIPTION
## 变更概述

实现 Issue #8「AI 自荐功能」所有功能需求。在 REQ-008 提名表单基础上扩展自荐专属字段。

## 自荐模式新增字段

| 字段 | 必填 | 说明 |
|------|------|------|
| 详细介绍 | ✅ | 100~1000 字（提名是 50~500），支持 Markdown，字数实时计数 |
| 创意说明 | ✅ | 50~300 字，为什么做它、有什么不同 |
| 作者昵称 | ✅ | 公开展示用（提名时选填） |
| 联系邮箱 | ✅ | 不对外展示（提名时为「联系方式」选填） |
| 官网/GitHub 链接 | ❌ | 实时 URL 格式校验 |
| 同意公开作者信息 | ✅ | checkbox，勾选后详情页展示「作者自荐」标签 + 昵称 |

## 实现细节

### 表单（/submit）
- 自荐/提名切换后字段动态显示/隐藏
- 自荐区域视觉区分（蓝色背景）
- 自荐时作者昵称、联系邮箱变为必填

### API Route（/api/submit）
- 自荐独立校验分支：字数范围更宽（详细介绍 100~1000），昵称/邮箱必填
- 官网/GitHub URL 格式 server 端校验

### Schema 扩展
```prisma
model Submission {
  creativeReason String? // 创意说明（自荐专属）
  githubUrl      String? // 官网/GitHub（自荐专属）
}
```

### 详情页展示
- 已有「作者自荐」标签逻辑（isPublic=true → 展示标签+昵称；isPublic=false → 仅标签）
- 本 PR 确认联动正确

## 验收清单
- [x] 自荐表单包含所有必填字段
- [x] 联系邮箱不在前台展示（submitterEmail 只在后台可见）
- [x] 管理后台来源标注「自荐」（type=SELF）
- [x] 详情页作者信息展示逻辑正确（isPublic 控制昵称显示）
- [x] 支持 Markdown 输入（详细介绍字段提示文字说明）
- [x] 本地 build 通过 ✅

Closes #8