### PR TITLE
fix: 校正点赞数弹窗「校正原因」placeholder 文案 (#84)

### DIFF
--- a/src/app/admin/projects/ProjectListActions.tsx
+++ b/src/app/admin/projects/ProjectListActions.tsx
@@ -74,7 +74,7 @@ export default function ProjectListActions({ id, slug, isActive, likesCount }: P
               </div>
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">校正原因 <span className="text-red-500">*</span></label>
-                <textarea name="reason" rows={2} required placeholder="例如：移除刷票数据" className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:border-indigo-500 resize-none" />
+                <textarea name="reason" rows={2} required placeholder="例如：冷启动补热度、活动推广补票" className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:border-indigo-500 resize-none" />
               </div>
               {adjustState?.error && (
                 <p className="text-xs text-red-500">{adjustState.error}</p>


### PR DESCRIPTION
## 变更说明

修复 #84

将管理后台「校正点赞数」弹窗中，「校正原因」输入框的 placeholder 从：

> 例如：移除刷票数据

改为：

> 例如：冷启动补热度、活动推广补票

## 原因

原文案描述的「移除刷票数据」与该功能实际用途（冷启动补热度）不符，容易误导管理员。新文案准确反映了功能设计意图。

## 测试

- [x] 改动仅涉及 UI 文案（placeholder），无逻辑变更
- [x] 本地确认文件修改正确